### PR TITLE
Support deleting/cleaning up CertificateRequest objects for volumes

### DIFF
--- a/deploy/cert-manager-csi-driver.yaml
+++ b/deploy/cert-manager-csi-driver.yaml
@@ -20,7 +20,7 @@ metadata:
 rules:
 - apiGroups: ["cert-manager.io"]
   resources: ["certificaterequests"]
-  verbs: ["get", "list", "watch", "create"]
+  verbs: ["get", "list", "watch", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/example/main.go
+++ b/example/main.go
@@ -91,6 +91,7 @@ func main() {
 			MetadataReader:     store,
 			Clock:              clock.RealClock{},
 			Log:                log,
+			NodeID:             *nodeID,
 			GeneratePrivateKey: (&keygen{store: store}).generatePrivateKey,
 			GenerateRequest:    generateRequest,
 			SignRequest:        signRequest,

--- a/internal/api/consts.go
+++ b/internal/api/consts.go
@@ -1,0 +1,6 @@
+package api
+
+const (
+	NodeIDHashLabelKey   = "csi.cert-manager.io/node-id-hash"
+	VolumeIDHashLabelKey = "csi.cert-manager.io/volume-id-hash"
+)

--- a/internal/api/util/hash.go
+++ b/internal/api/util/hash.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"fmt"
+	"hash/fnv"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+// HashIdentifier is the function used to hash a Node ID or Volume ID for use
+// as a label value on created CertificateRequest resources.
+func HashIdentifier(s string) string {
+	hf := fnv.New32()
+	hf.Write([]byte(s))
+	return rand.SafeEncodeString(fmt.Sprint(hf.Sum32()))
+}

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -210,7 +210,7 @@ func (m *Manager) issue(volumeID string) error {
 	log := m.log.WithValues("volume_id", volumeID)
 	log.Info("Processing issuance")
 
-	if err := m.cleanupStaleRequests(ctx, volumeID); err != nil {
+	if err := m.cleanupStaleRequests(ctx, log, volumeID); err != nil {
 		return fmt.Errorf("cleaning up stale requests: %w", err)
 	}
 
@@ -303,7 +303,7 @@ func (m *Manager) issue(volumeID string) error {
 	return nil
 }
 
-func (m *Manager) cleanupStaleRequests(ctx context.Context, volumeID string) error {
+func (m *Manager) cleanupStaleRequests(ctx context.Context, log logr.Logger, volumeID string) error {
 	sel, err := m.labelSelectorForVolume(volumeID)
 	if err != nil {
 		return fmt.Errorf("internal error building label selector - this is a bug, please open an issue: %w", err)
@@ -333,6 +333,8 @@ func (m *Manager) cleanupStaleRequests(ctx context.Context, volumeID string) err
 				return fmt.Errorf("deleting old certificaterequest: %w", err)
 			}
 		}
+
+		log.Info("Deleted CertificateRequest resource", "name", toDelete.Name, "namespace", toDelete.Namespace)
 	}
 
 	return nil

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -47,7 +47,7 @@ type Options struct {
 
 	// Maximum number of CertificateRequests that should exist for each
 	// volume mounted into a pod.
-	// If not set, this will be defaulted to 3.
+	// If not set, this will be defaulted to 1.
 	// When the number of CertificateRequests for a volume exceeds this limit,
 	// requests will be deleted before any new ones are created.
 	MaxRequestsPerVolume int
@@ -91,7 +91,7 @@ func NewManager(opts Options) (*Manager, error) {
 		return nil, errors.New("WriteKeypair must be set")
 	}
 	if opts.MaxRequestsPerVolume == 0 {
-		opts.MaxRequestsPerVolume = 3
+		opts.MaxRequestsPerVolume = 1
 	}
 	if opts.MaxRequestsPerVolume < 0 {
 		return nil, errors.New("MaxRequestsPerVolume cannot be less than zero")

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -49,7 +49,7 @@ type Options struct {
 	// volume mounted into a pod.
 	// If not set, this will be defaulted to 3.
 	// When the number of CertificateRequests for a volume exceeds this limit,
-	// requestss will be deleted before any new ones are created.
+	// requests will be deleted before any new ones are created.
 	MaxRequestsPerVolume int
 
 	// NodeID is a unique identifier for the node.

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -10,8 +10,13 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclock "k8s.io/utils/clock/testing"
 
+	internalapi "github.com/cert-manager/csi-lib/internal/api"
+	internalapiutil "github.com/cert-manager/csi-lib/internal/api/util"
 	"github.com/cert-manager/csi-lib/manager"
 	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/cert-manager/csi-lib/storage"
@@ -79,5 +84,88 @@ func TestIssuesCertificate(t *testing.T) {
 	}
 	if !reflect.DeepEqual(files["cert"], []byte("certificate bytes")) {
 		t.Errorf("unexpected certificate data: %v", files["cert"])
+	}
+}
+
+func TestManager_CleansUpOldRequests(t *testing.T) {
+	store := storage.NewMemoryFS()
+	clock := fakeclock.NewFakeClock(time.Now())
+	opts, cl, stop := testutil.RunTestDriver(t, testutil.DriverOptions{
+		Store:                store,
+		Clock:                clock,
+		MaxRequestsPerVolume: 1,
+		NodeID:               "node-id",
+		GenerateRequest: func(_ metadata.Metadata) (*manager.CertificateRequestBundle, error) {
+			return &manager.CertificateRequestBundle{
+				Namespace: "testns",
+			}, nil
+		},
+		WriteKeypair: func(meta metadata.Metadata, key crypto.PrivateKey, chain []byte, ca []byte) error {
+			store.WriteFiles(meta.VolumeID, map[string][]byte{
+				"ca":   ca,
+				"cert": chain,
+			})
+			nextIssuanceTime := clock.Now().Add(time.Hour)
+			meta.NextIssuanceTime = &nextIssuanceTime
+			return store.WriteMetadata(meta.VolumeID, meta)
+		},
+	})
+	defer stop()
+
+	// precreate a single certificaterequest
+	crLabels := map[string]string{
+		internalapi.NodeIDHashLabelKey:   internalapiutil.HashIdentifier(opts.NodeID),
+		internalapi.VolumeIDHashLabelKey: internalapiutil.HashIdentifier("volume-id"),
+	}
+	cr := &cmapi.CertificateRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cr",
+			Namespace: "testns",
+			Labels:    crLabels,
+		},
+		Spec:   cmapi.CertificateRequestSpec{},
+		Status: cmapi.CertificateRequestStatus{},
+	}
+	cr, err := opts.Client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(context.TODO(), cr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up a goroutine that automatically issues all CertificateRequests
+	stopCh := make(chan struct{})
+	go testutil.IssueAllRequests(t, opts.Client, "testns", stopCh, []byte("certificate bytes"), []byte("ca bytes"))
+	defer close(stopCh)
+
+	// Call NodePublishVolume
+	tmpDir, err := os.MkdirTemp("", "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	_, err = cl.NodePublishVolume(context.TODO(), &csi.NodePublishVolumeRequest{
+		VolumeId: "volume-id",
+		VolumeContext: map[string]string{
+			"csi.storage.k8s.io/ephemeral":     "true",
+			"csi.storage.k8s.io/pod.name":      "the-pod-name",
+			"csi.storage.k8s.io/pod.namespace": "testns",
+		},
+		TargetPath: tmpDir,
+		Readonly:   true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = opts.Client.CertmanagerV1().CertificateRequests("testns").Get(context.TODO(), "test-cr", metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Error("Expected 'test-cr' resource to be deleted but it still exists")
+	}
+
+	all, err := opts.Client.CertmanagerV1().CertificateRequests("testns").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all.Items) != 1 {
+		t.Errorf("Expected one CertificateRequest resource to still exist, but there is %d", len(all.Items))
 	}
 }

--- a/test/util/testutil.go
+++ b/test/util/testutil.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"context"
+	"crypto"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"testing"
@@ -21,6 +23,7 @@ import (
 
 	"github.com/cert-manager/csi-lib/driver"
 	"github.com/cert-manager/csi-lib/manager"
+	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/cert-manager/csi-lib/storage"
 	testlogr "github.com/cert-manager/csi-lib/test/log"
 )
@@ -31,6 +34,9 @@ type DriverOptions struct {
 	Log     logr.Logger
 	Client  cmclient.Interface
 	Mounter mount.Interface
+
+	NodeID               string
+	MaxRequestsPerVolume int
 
 	GeneratePrivateKey manager.GeneratePrivateKeyFunc
 	GenerateRequest    manager.GenerateRequestFunc
@@ -54,26 +60,52 @@ func RunTestDriver(t *testing.T, opts DriverOptions) (DriverOptions, csi.NodeCli
 	if opts.Mounter == nil {
 		opts.Mounter = mount.NewFakeMounter(nil)
 	}
+	if opts.NodeID == "" {
+		opts.NodeID = "test-node"
+	}
+	if opts.GeneratePrivateKey == nil {
+		opts.GeneratePrivateKey = func(_ metadata.Metadata) (crypto.PrivateKey, error) {
+			return nil, nil
+		}
+	}
+	if opts.GenerateRequest == nil {
+		opts.GenerateRequest = func(_ metadata.Metadata) (*manager.CertificateRequestBundle, error) {
+			return &manager.CertificateRequestBundle{}, nil
+		}
+	}
+	if opts.SignRequest == nil {
+		opts.SignRequest = func(_ metadata.Metadata, _ crypto.PrivateKey, _ *x509.CertificateRequest) ([]byte, error) {
+			return []byte{}, nil
+		}
+	}
+	if opts.WriteKeypair == nil {
+		opts.WriteKeypair = func(_ metadata.Metadata, _ crypto.PrivateKey, _ []byte, _ []byte) error {
+			return nil
+		}
+	}
+
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to setup test listener: %v", err)
 	}
 
 	m := manager.NewManagerOrDie(manager.Options{
-		Client:             opts.Client,
-		MetadataReader:     opts.Store,
-		Clock:              opts.Clock,
-		Log:                opts.Log,
-		GeneratePrivateKey: opts.GeneratePrivateKey,
-		GenerateRequest:    opts.GenerateRequest,
-		SignRequest:        opts.SignRequest,
-		WriteKeypair:       opts.WriteKeypair,
+		Client:               opts.Client,
+		MetadataReader:       opts.Store,
+		Clock:                opts.Clock,
+		Log:                  opts.Log,
+		NodeID:               opts.NodeID,
+		MaxRequestsPerVolume: opts.MaxRequestsPerVolume,
+		GeneratePrivateKey:   opts.GeneratePrivateKey,
+		GenerateRequest:      opts.GenerateRequest,
+		SignRequest:          opts.SignRequest,
+		WriteKeypair:         opts.WriteKeypair,
 	})
 
 	d := driver.NewWithListener(lis, opts.Log, driver.Options{
 		DriverName:    "driver-name",
 		DriverVersion: "v0.0.1",
-		NodeID:        "node-id",
+		NodeID:        opts.NodeID,
 		Store:         opts.Store,
 		Mounter:       opts.Mounter,
 		Manager:       m,
@@ -138,4 +170,35 @@ func IssueOneRequest(t *testing.T, client cmclient.Interface, namespace string, 
 	}, stopCh); err != nil {
 		t.Errorf("error automatically issuing certificaterequest: %v", err)
 	}
+}
+
+func IssueAllRequests(t *testing.T, client cmclient.Interface, namespace string, stopCh <-chan struct{}, cert, ca []byte) {
+	wait.Until(func() {
+		reqs, err := client.CertmanagerV1().CertificateRequests(namespace).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, req := range reqs.Items {
+			if len(req.Status.Certificate) != 0 {
+				continue
+			}
+
+			csr := req.DeepCopy()
+			csr.Status.Conditions = append(req.Status.Conditions, cmapi.CertificateRequestCondition{
+				Type:    cmapi.CertificateRequestConditionReady,
+				Status:  cmmeta.ConditionTrue,
+				Reason:  cmapi.CertificateRequestReasonIssued,
+				Message: "Issued by test",
+			})
+
+			csr.Status.Certificate = cert
+			csr.Status.CA = ca
+			_, err = client.CertmanagerV1().CertificateRequests(namespace).UpdateStatus(context.TODO(), csr, metav1.UpdateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+	}, time.Millisecond*50, stopCh)
 }


### PR DESCRIPTION
This implements the cleanup portion of what's described in the `certificaterequest-management.md` design document.

It allows the driver to delete 'old' CertificateRequest resources (up to a configurable limit) to avoid creating an excessive number of resources, impacting the stability of the apiserver.