### PR TITLE
Expect PEM data to be returned by SignRequestFunc instead of DER

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -191,7 +191,15 @@ func generateRequest(meta metadata.Metadata) (*manager.CertificateRequestBundle,
 }
 
 func signRequest(_ metadata.Metadata, key crypto.PrivateKey, request *x509.CertificateRequest) ([]byte, error) {
-	return x509.CreateCertificateRequest(rand.Reader, request, key)
+	csrDer, err := x509.CreateCertificateRequest(rand.Reader, request, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csrDer,
+	}), nil
 }
 
 // writer wraps the storage backend to allow access for writing data

--- a/manager/interfaces.go
+++ b/manager/interfaces.go
@@ -52,13 +52,13 @@ type CertificateRequestBundle struct {
 	Annotations map[string]string
 }
 
-// SignRequestFunc returns the signed CSR bytes (in DER format) for the given
+// SignRequestFunc returns the signed CSR bytes (in PEM format) for the given
 // x509.CertificateRequest.
 // The private key passed to this function is one that is returned by the
 // GeneratePrivateKeyFunc and should be treated as implementation specific.
 // For example, it may be a reference to a location where a private key is
 // stored rather than containing actual private key data.
-type SignRequestFunc func(meta metadata.Metadata, key crypto.PrivateKey, request *x509.CertificateRequest) (csr []byte, err error)
+type SignRequestFunc func(meta metadata.Metadata, key crypto.PrivateKey, request *x509.CertificateRequest) (pem []byte, err error)
 
 // WriteKeypairFunc encodes & persists the output from a completed CertificateRequest
 // into whatever storage backend is provided.


### PR DESCRIPTION
This PR changes the public/exported interface (that consumers will implement) for the library to shift the responsibility for encoding to PEM to the implementor of the library.

This is to allow implementors to add e.g. trailing PEM comments (which are permitted by both the PEM spec and the Certificate(Signing)Request API). These may be used for any purpose, including (but not limited to) attaching additional attestation information that does not fit within the x509 document.
