### PR TITLE
Adds ClientForMatadataFunc to manager 

### DIFF
--- a/driver/nodeserver.go
+++ b/driver/nodeserver.go
@@ -103,6 +103,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 
 	if !notMnt {
 		// Nothing more to do if the targetPath is already a bind mount
+		success = true
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 

--- a/manager/interfaces.go
+++ b/manager/interfaces.go
@@ -23,6 +23,7 @@ import (
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 
 	"github.com/cert-manager/csi-lib/metadata"
 )
@@ -82,3 +83,8 @@ type SignRequestFunc func(meta metadata.Metadata, key crypto.PrivateKey, request
 // The 'chain' and 'ca' arguments are PEM encoded and sourced directly from the
 // CertificateRequest, without any attempt to parse or decode the bytes.
 type WriteKeypairFunc func(meta metadata.Metadata, key crypto.PrivateKey, chain []byte, ca []byte) error
+
+// CreateClientFunc will return a cert-manager API client used for creating
+// objects. This is called with the metadata associated with the volume being
+// published. Useful for modifying clients to make use of CSI token requests.
+type CreateClientFunc func(meta metadata.Metadata) (cmclient.Interface, error)

--- a/manager/interfaces.go
+++ b/manager/interfaces.go
@@ -84,7 +84,8 @@ type SignRequestFunc func(meta metadata.Metadata, key crypto.PrivateKey, request
 // CertificateRequest, without any attempt to parse or decode the bytes.
 type WriteKeypairFunc func(meta metadata.Metadata, key crypto.PrivateKey, chain []byte, ca []byte) error
 
-// CreateClientFunc will return a cert-manager API client used for creating
-// objects. This is called with the metadata associated with the volume being
-// published. Useful for modifying clients to make use of CSI token requests.
-type CreateClientFunc func(meta metadata.Metadata) (cmclient.Interface, error)
+// ClientForMatadataFunc will return a cert-manager API client used for
+// creating objects. This is called with the metadata associated with the
+// volume being published. Useful for modifying clients to make use of CSI
+// token requests.
+type ClientForMatadataFunc func(meta metadata.Metadata) (cmclient.Interface, error)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -51,9 +51,10 @@ type Options struct {
 	// requests.
 	Client cmclient.Interface
 
-	// CreateClient is used for returning a client that is used for creating
-	// cert-manager API objects. If nil, Client will always be used.
-	CreateClient CreateClientFunc
+	// ClientForMatadataFunc is used for returning a client that is used for
+	// creating cert-manager API objects given a volume's metadata. If nil,
+	// Client will always be used.
+	ClientForMatadata ClientForMatadataFunc
 
 	// Used the read metadata from the storage backend
 	MetadataReader storage.MetadataReader
@@ -89,8 +90,8 @@ func NewManager(opts Options) (*Manager, error) {
 	if opts.Client == nil {
 		return nil, errors.New("Client must be set")
 	}
-	if opts.CreateClient == nil {
-		opts.CreateClient = func(_ metadata.Metadata) (cmclient.Interface, error) {
+	if opts.ClientForMatadata == nil {
+		opts.ClientForMatadata = func(_ metadata.Metadata) (cmclient.Interface, error) {
 			return opts.Client, nil
 		}
 	}
@@ -143,12 +144,12 @@ func NewManager(opts Options) (*Manager, error) {
 	informerFactory.WaitForCacheSync(stopCh)
 
 	m := &Manager{
-		client:         opts.Client,
-		createClient:   opts.CreateClient,
-		lister:         lister,
-		metadataReader: opts.MetadataReader,
-		clock:          opts.Clock,
-		log:            opts.Log,
+		client:            opts.Client,
+		clientForMetadata: opts.ClientForMatadata,
+		lister:            lister,
+		metadataReader:    opts.MetadataReader,
+		clock:             opts.Clock,
+		log:               opts.Log,
 
 		generatePrivateKey: opts.GeneratePrivateKey,
 		generateRequest:    opts.GenerateRequest,
@@ -198,8 +199,9 @@ type Manager struct {
 	// client used to delete objects in the cert-manager API
 	client cmclient.Interface
 
-	// createClient used to create objects in the cert-manager API
-	createClient CreateClientFunc
+	// clientForMetadata used to create objects in the cert-manager API given a
+	// volume's metadata
+	clientForMetadata ClientForMatadataFunc
 
 	// lister is used as a read-only cache of CertificateRequest resources
 	lister cmlisters.CertificateRequestLister
@@ -414,7 +416,7 @@ func (m *Manager) submitRequest(ctx context.Context, meta metadata.Metadata, csr
 		},
 	}
 
-	createClient, err := m.createClient(meta)
+	createClient, err := m.clientForMetadata(meta)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get create client for %q: %w", meta.VolumeID, err)
 	}

--- a/storage/filesystem.go
+++ b/storage/filesystem.go
@@ -166,6 +166,7 @@ func (f *Filesystem) RegisterMetadata(meta metadata.Metadata) (bool, error) {
 		return true, f.WriteMetadata(meta.VolumeID, meta)
 	}
 
+	// If the volume context has changed, should write updated metadata
 	if !apiequality.Semantic.DeepEqual(existingMeta.VolumeContext, meta.VolumeContext) {
 		f.log.WithValues("volume_id", meta.VolumeID).Info("volume context changed, updating file system metadata")
 		existingMeta.VolumeContext = meta.VolumeContext

--- a/storage/filesystem.go
+++ b/storage/filesystem.go
@@ -168,7 +168,8 @@ func (f *Filesystem) RegisterMetadata(meta metadata.Metadata) (bool, error) {
 
 	if !apiequality.Semantic.DeepEqual(existingMeta.VolumeContext, meta.VolumeContext) {
 		f.log.WithValues("volume_id", meta.VolumeID).Info("volume context changed, updating file system metadata")
-		return true, f.WriteMetadata(meta.VolumeID, meta)
+		existingMeta.VolumeContext = meta.VolumeContext
+		return true, f.WriteMetadata(existingMeta.VolumeID, existingMeta)
 	}
 
 	return false, nil

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -60,10 +60,11 @@ type MetadataWriter interface {
 	// If the directory for this volume does not exist, it will return an error.
 	WriteMetadata(volumeID string, meta metadata.Metadata) error
 
-	// RegisterMetadata will create a directory for the given metadata and,
-	// if the metadata file does not already exist, persist the given metadata
-	// file.
-	// It will return true if the metadata file has been written, false otherwise.
+	// RegisterMetadata will create a directory for the given metadata and, if
+	// the metadata file does not already exist or volume context has changed,
+	// persist the given metadata file.
+	// It will return true if the metadata file has been written, false
+	// otherwise.
 	RegisterMetadata(meta metadata.Metadata) (bool, error)
 }
 


### PR DESCRIPTION
This PR adds an optional option to the manager: `ClientForMetadata`. This takes a function which returns a cert-manager client based on the passed Volume metadata. This is designed to be used to generate on the fly cert-manager clients that make use of [CSI token requests](https://kubernetes-csi.github.io/docs/token-requests.html). CertificateRequests created by this client will then have the UserInfo of the pod who owns that Volume. This allows a CSI driver to request identity documents on the pods behalf, whilst an approver can validate the contents of the certificate request matches that of the pod.

By default this is unset, which means the `Client` cert-manager client will be used to create CertificateRequests.

I have modified the filesystems `RegisterMetadata` func so that it will write to file also when the volume context has changed. This is important as the Kubelet will call `NodePublishVolume` again when the current token has expired, passing a new one. Without this change, the driver would continue to use a stale token which would result in certificate renewals being rejected.

---

Sets `success` to `true` when `targetPath` is already a bind point to prevent Unmounting an already successful mount point.

/cc @munnerz 