### PR TITLE
Adds ClientForMetadataTokenRequestEmptyAud and EmptyAudienceTokenFromMetadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/jetstack/cert-manager v1.3.1
 	github.com/kubernetes-csi/csi-lib-utils v0.9.1
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
 	google.golang.org/grpc v1.37.0
 	k8s.io/apimachinery v0.21.0

--- a/manager/util/tokenrequest.go
+++ b/manager/util/tokenrequest.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	"k8s.io/client-go/rest"
+
+	"github.com/cert-manager/csi-lib/manager"
+	"github.com/cert-manager/csi-lib/metadata"
+)
+
+// ClientForMetadataTokenRequestEmptyAud returns a
+// manager.ClientForMetadataFunc that returns a cert-manager rest client whose
+// authentication is built using the passed empty audience ("") token request
+// in the metadata VolumeContext. The resulting cert-manager client is
+// authenticated against the Kubernetes API server using the mounting Pod's
+// ServiceAccount.
+//
+// Intended to be used as a manager ClientForMetadata so that created
+// CertificateRequests will have UserInfo fields of the mounting Pods
+// ServiceAccount.
+//
+// Drivers using this function _must_ have the empty audience tokenRequest
+// defined on the CSIDriver manifest definition, along with setting
+// requiresRepublish to true:
+//
+// tokenRequests:
+//   - audience: ""
+//     expirationSeconds: 3600
+// requiresRepublish: true
+//
+// restConfig must contain the Kubernetes API server Host, and a valid
+// TLSClientConfig.
+func ClientForMetadataTokenRequestEmptyAud(restConfig *rest.Config) manager.ClientForMetadataFunc {
+	restConfigGetter := restConfigForMetadataTokenRequestEmptyAud(restConfig)
+	return func(meta metadata.Metadata) (cmclient.Interface, error) {
+		cmRestConfig, err := restConfigGetter(meta)
+		if err != nil {
+			return nil, err
+		}
+		return cmclient.NewForConfig(cmRestConfig)
+	}
+}
+
+// restConfigForMetadataTokenRequestEmptyAud returns a Kubernetes rest config
+// getter that returns a rest config that is authenticated using a
+// ServiceAccount defined in the empty audience token request passed in the
+// volume context.
+// The Host, TLSClientConfig, UserAgent, Timeout, and Proxy are preserved from
+// the seed rest config.
+func restConfigForMetadataTokenRequestEmptyAud(restConfig *rest.Config) func(meta metadata.Metadata) (*rest.Config, error) {
+	host := restConfig.Host
+	tlsClientConfig := *restConfig.DeepCopy()
+	userAgent := restConfig.UserAgent
+	timeout := restConfig.Timeout
+	proxy := restConfig.Proxy
+
+	return func(meta metadata.Metadata) (*rest.Config, error) {
+		apiToken, err := EmptyAudienceTokenFromMetadata(meta)
+		if err != nil {
+			return nil, err
+		}
+
+		return &rest.Config{
+			Host:            host,
+			TLSClientConfig: tlsClientConfig,
+			UserAgent:       userAgent,
+			Timeout:         timeout,
+			Proxy:           proxy,
+			BearerToken:     apiToken,
+		}, nil
+	}
+}
+
+// EmptyAudienceTokenFromMetadata returns the empty audience service account
+// token from the volume attributes contained within the metadata. This token
+// should be present in the token request
+// `csi.storage.k8s.io/serviceAccount.tokens` key of the metadata
+// VolumeContext.
+// This function will only return tokens if the CSI driver has been defined
+// with tokenRequests enabled with an empty ("") audience.
+func EmptyAudienceTokenFromMetadata(meta metadata.Metadata) (string, error) {
+	tokens := make(map[string]struct {
+		Token string `json:"token"`
+	})
+
+	tokensJson, ok := meta.VolumeContext["csi.storage.k8s.io/serviceAccount.tokens"]
+	if !ok {
+		return "", errors.New("'csi.storage.k8s.io/serviceAccount.tokens' not present in volume context, driver likely doesn't have token requests enabled")
+	}
+
+	err := json.Unmarshal([]byte(tokensJson), &tokens)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse service account tokens from CSI volume context: %w",
+			err)
+	}
+
+	apiToken, ok := tokens[""]
+	if !ok || len(apiToken.Token) == 0 {
+		return "", errors.New("empty audience service account token doesn't exist in CSI volume context, driver likely doesn't have an empty audience token request configured")
+	}
+
+	return apiToken.Token, nil
+}

--- a/manager/util/tokenrequest_test.go
+++ b/manager/util/tokenrequest_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/cert-manager/csi-lib/metadata"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_restConfigForMetadataTokenRequestEmptyAud(t *testing.T) {
+	var (
+		baseRestConfig = &rest.Config{
+			Host: "my-host",
+			TLSClientConfig: rest.TLSClientConfig{
+				ServerName: "my-server",
+			},
+			BearerToken: "my-token",
+			UserAgent:   "csi.cert-manager.io/unit-tests",
+			Timeout:     time.Millisecond,
+		}
+	)
+
+	tests := map[string]struct {
+		volumeContext map[string]string
+		expRestConfig *rest.Config
+		expErr        bool
+	}{
+		"volume context doesn't contain any token requests should error": {
+			volumeContext: map[string]string{},
+			expRestConfig: nil,
+			expErr:        true,
+		},
+		"volume context contains token request entry but json is garbage should error": {
+			volumeContext: map[string]string{
+				"csi.storage.k8s.io/serviceAccount.tokens": "garbage-data",
+			},
+			expRestConfig: nil,
+			expErr:        true,
+		},
+		"volume context contains token requests, but not an empty audience should error": {
+			volumeContext: map[string]string{
+				"csi.storage.k8s.io/serviceAccount.tokens": `
+		{
+		  "vault": {
+		    "token": "vault-token",
+		    "expiry": "Wed, 11 Aug 2021 09:03:03 GMT"
+		  },
+		  "kubernetes.io": {
+		    "token": "kube-token",
+		    "expiry": "Wed, 11 Aug 2021 09:03:03 GMT"
+			}
+		}
+		`,
+			},
+			expRestConfig: nil,
+			expErr:        true,
+		},
+		"volume context contains only an empty audience token should return a rest config with token": {
+			volumeContext: map[string]string{
+				"csi.storage.k8s.io/serviceAccount.tokens": `
+		{
+		  "": {
+		    "token": "empty-aud-token",
+		    "expiry": "Wed, 11 Aug 2021 09:03:03 GMT"
+			}
+		}
+		`,
+			},
+			expRestConfig: &rest.Config{
+				Host: "my-host",
+				TLSClientConfig: rest.TLSClientConfig{
+					ServerName: "my-server",
+				},
+				UserAgent:   "csi.cert-manager.io/unit-tests",
+				Timeout:     time.Millisecond,
+				BearerToken: "empty-aud-token",
+			},
+			expErr: false,
+		},
+		"volume context contains multiple request tokens including the empty audience should return a rest config with empty audience token": {
+			volumeContext: map[string]string{
+				"csi.storage.k8s.io/serviceAccount.tokens": `
+		{
+		  "vault": {
+		    "token": "vault-token",
+		    "expiry": "Wed, 11 Aug 2021 09:03:03 GMT"
+		  },
+		  "": {
+		    "token": "another-empty-aud-token",
+		    "expiry": "Wed, 11 Aug 2021 09:03:03 GMT"
+			},
+		  "kubernetes.io": {
+		    "token": "kube-token",
+		    "expiry": "Wed, 11 Aug 2021 09:03:03 GMT"
+			}
+		}
+		`,
+			},
+			expRestConfig: &rest.Config{
+				Host: "my-host",
+				TLSClientConfig: rest.TLSClientConfig{
+					ServerName: "my-server",
+				},
+				UserAgent:   "csi.cert-manager.io/unit-tests",
+				Timeout:     time.Millisecond,
+				BearerToken: "another-empty-aud-token",
+			},
+			expErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			restConfig, gotErr := restConfigForMetadataTokenRequestEmptyAud(baseRestConfig)(metadata.Metadata{VolumeContext: test.volumeContext})
+			assert.Equal(t, test.expErr, gotErr != nil, "%v", gotErr)
+			assert.Equal(t, test.expRestConfig, restConfig)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the `manager/util` package which is intended to include helper functions for csi-lib consumers.

`EmptyAudienceTokenFromMetadata` will return the empty audience request token from the volume context. This is useful for drivers who want to extract the Pod's ServiceAccount information without needed to GET Pods.

`ClientForMetadataTokenRequestEmptyAud` is intended to be plugged straight into `manager.ClientForMetadata` and will be used to generate cert-manager clients who authenticate to the API server using the Pod's ServiceAccount. 

I have ended up copying these funcs multiple times, so seems sensible to add these util helpers to csi-lib so other consumers don't have to write them themselves.

```release-note
NONE
```

/assign @munnerz 