### PR TITLE
Add option to skip blocking pod startup if driver is not ready to create a request yet

### DIFF
--- a/manager/interfaces.go
+++ b/manager/interfaces.go
@@ -89,3 +89,14 @@ type WriteKeypairFunc func(meta metadata.Metadata, key crypto.PrivateKey, chain 
 // volume being published. Useful for modifying clients to make use of CSI
 // token requests.
 type ClientForMetadataFunc func(meta metadata.Metadata) (cmclient.Interface, error)
+
+// ReadyToRequestFunc can be optionally implemented by drivers to indicate whether
+// the driver is ready to request a certificate for the given volume/metadata.
+// This can be used to 'defer' fetching until later pod initialization events have
+// happened (e.g. CNI has allocated an IP if you want to embed a pod IP into the certificate
+// request resources).
+type ReadyToRequestFunc func(meta metadata.Metadata) bool
+
+func AlwaysReadyToRequest(_ metadata.Metadata) bool {
+	return true
+}

--- a/manager/interfaces.go
+++ b/manager/interfaces.go
@@ -95,8 +95,8 @@ type ClientForMetadataFunc func(meta metadata.Metadata) (cmclient.Interface, err
 // This can be used to 'defer' fetching until later pod initialization events have
 // happened (e.g. CNI has allocated an IP if you want to embed a pod IP into the certificate
 // request resources).
-type ReadyToRequestFunc func(meta metadata.Metadata) bool
+type ReadyToRequestFunc func(meta metadata.Metadata) (bool, string)
 
-func AlwaysReadyToRequest(_ metadata.Metadata) bool {
-	return true
+func AlwaysReadyToRequest(_ metadata.Metadata) (bool, string) {
+	return true, ""
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -258,8 +258,8 @@ func (m *Manager) issue(volumeID string) error {
 	}
 	log.V(2).Info("Read metadata", "metadata", meta)
 
-	if !m.readyToRequest(meta) {
-		return fmt.Errorf("driver is not ready to request a certificate for this volume")
+	if ready, reason := m.readyToRequest(meta); !ready {
+		return fmt.Errorf("driver is not ready to request a certificate for this volume: %v", reason)
 	}
 
 	key, err := m.generatePrivateKey(meta)
@@ -536,11 +536,11 @@ func (m *Manager) UnmanageVolume(volumeID string) {
 	}
 }
 
-func (m *Manager) IsVolumeReadyToRequest(volumeID string) bool {
+func (m *Manager) IsVolumeReadyToRequest(volumeID string) (bool, string) {
 	meta, err := m.metadataReader.ReadMetadata(volumeID)
 	if err != nil {
 		m.log.Error(err, "failed to read metadata", "volume_id", volumeID)
-		return false
+		return false, ""
 	}
 
 	return m.readyToRequest(meta)

--- a/storage/filesystem.go
+++ b/storage/filesystem.go
@@ -124,7 +124,7 @@ func (f *Filesystem) ListVolumes() ([]string, error) {
 	return vols, nil
 }
 
-// MetadataForVolume will return the metadata for the volume with the given ID.
+// ReadMetadata will return the metadata for the volume with the given ID.
 // Errors wrapping ErrNotFound will be returned if metadata for the ID cannot
 // be found.
 func (f *Filesystem) ReadMetadata(volumeID string) (metadata.Metadata, error) {

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -146,5 +146,10 @@ func (m *MemoryFS) ReadFiles(volumeID string) (map[string][]byte, error) {
 	if !ok {
 		return nil, ErrNotFound
 	}
-	return vol, nil
+	// make a copy of the map to ensure no races can occur
+	cpy := make(map[string][]byte)
+	for k, v := range vol {
+		cpy[k] = v
+	}
+	return cpy, nil
 }

--- a/test/integration/ready_to_request_test.go
+++ b/test/integration/ready_to_request_test.go
@@ -163,13 +163,12 @@ func TestFailsIfNotReadyToRequest_ContinueOnNotReadyDisabled(t *testing.T) {
 	stopCh := make(chan struct{})
 	go testutil.IssueAllRequests(t, opts.Client, "certificaterequest-namespace", stopCh, []byte("certificate bytes"), []byte("ca bytes"))
 	defer close(stopCh)
-
 	tmpDir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	_, err = cl.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
 		VolumeId: "test-vol",

--- a/test/integration/ready_to_request_test.go
+++ b/test/integration/ready_to_request_test.go
@@ -189,7 +189,7 @@ func TestFailsIfNotReadyToRequest_ContinueOnNotReadyDisabled(t *testing.T) {
 	// being cleaned up of the persisted metadata file.
 	ctx, cancel2 := context.WithTimeout(context.Background(), time.Second)
 	defer cancel2()
-	if wait.PollUntil(time.Millisecond*100, func() (bool, error) {
+	if err := wait.PollUntil(time.Millisecond*100, func() (bool, error) {
 		_, err := store.ReadFiles("test-vol")
 		if err != storage.ErrNotFound {
 			return false, nil

--- a/test/integration/ready_to_request_test.go
+++ b/test/integration/ready_to_request_test.go
@@ -39,7 +39,7 @@ import (
 	testutil "github.com/cert-manager/csi-lib/test/util"
 )
 
-func TestCompletesIfNotReadyToRequest(t *testing.T) {
+func Test_CompletesIfNotReadyToRequest_ContinueOnNotReadyEnabled(t *testing.T) {
 	store := storage.NewMemoryFS()
 	clock := fakeclock.NewFakeClock(time.Now())
 
@@ -48,13 +48,13 @@ func TestCompletesIfNotReadyToRequest(t *testing.T) {
 		Store:              store,
 		Clock:              clock,
 		ContinueOnNotReady: true,
-		ReadyToRequest: func(meta metadata.Metadata) bool {
+		ReadyToRequest: func(meta metadata.Metadata) (bool, string) {
 			if calls < 1 {
 				calls++
-				return false
+				return false, "calls < 1"
 			}
 			// only indicate we are ready after issuance has been attempted 1 time
-			return calls == 1
+			return calls == 1, "calls == 1"
 		},
 		GeneratePrivateKey: func(meta metadata.Metadata) (crypto.PrivateKey, error) {
 			return nil, nil
@@ -133,8 +133,8 @@ func TestFailsIfNotReadyToRequest_ContinueOnNotReadyDisabled(t *testing.T) {
 		Store:              store,
 		Clock:              clock,
 		ContinueOnNotReady: false,
-		ReadyToRequest: func(meta metadata.Metadata) bool {
-			return false
+		ReadyToRequest: func(meta metadata.Metadata) (bool, string) {
+			return false, "never ready"
 		},
 		GeneratePrivateKey: func(meta metadata.Metadata) (crypto.PrivateKey, error) {
 			return nil, nil

--- a/test/integration/ready_to_request_test.go
+++ b/test/integration/ready_to_request_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/util/wait"
+	fakeclock "k8s.io/utils/clock/testing"
+
+	"github.com/cert-manager/csi-lib/manager"
+	"github.com/cert-manager/csi-lib/metadata"
+	"github.com/cert-manager/csi-lib/storage"
+	testutil "github.com/cert-manager/csi-lib/test/util"
+)
+
+func TestCompletesIfNotReadyToRequest(t *testing.T) {
+	store := storage.NewMemoryFS()
+	clock := fakeclock.NewFakeClock(time.Now())
+
+	calls := 0
+	opts, cl, stop := testutil.RunTestDriver(t, testutil.DriverOptions{
+		Store:              store,
+		Clock:              clock,
+		ContinueOnNotReady: true,
+		ReadyToRequest: func(meta metadata.Metadata) bool {
+			if calls < 1 {
+				calls++
+				return false
+			}
+			// only indicate we are ready after issuance has been attempted 1 time
+			return calls == 1
+		},
+		GeneratePrivateKey: func(meta metadata.Metadata) (crypto.PrivateKey, error) {
+			return nil, nil
+		},
+		GenerateRequest: func(meta metadata.Metadata) (*manager.CertificateRequestBundle, error) {
+			return &manager.CertificateRequestBundle{
+				Namespace: "certificaterequest-namespace",
+			}, nil
+		},
+		SignRequest: func(meta metadata.Metadata, key crypto.PrivateKey, request *x509.CertificateRequest) (csr []byte, err error) {
+			return []byte{}, nil
+		},
+		WriteKeypair: func(meta metadata.Metadata, key crypto.PrivateKey, chain []byte, ca []byte) error {
+			store.WriteFiles(meta, map[string][]byte{
+				"ca":   ca,
+				"cert": chain,
+			})
+			nextIssuanceTime := clock.Now().Add(time.Hour)
+			meta.NextIssuanceTime = &nextIssuanceTime
+			return store.WriteMetadata(meta.VolumeID, meta)
+		},
+	})
+	defer stop()
+
+	// Setup a routine to issue/sign the request IF it is created
+	stopCh := make(chan struct{})
+	go testutil.IssueAllRequests(t, opts.Client, "certificaterequest-namespace", stopCh, []byte("certificate bytes"), []byte("ca bytes"))
+	defer close(stopCh)
+
+	tmpDir, err := os.MkdirTemp("", "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	_, err = cl.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
+		VolumeId: "test-vol",
+		VolumeContext: map[string]string{
+			"csi.storage.k8s.io/ephemeral":     "true",
+			"csi.storage.k8s.io/pod.name":      "the-pod-name",
+			"csi.storage.k8s.io/pod.namespace": "the-pod-namespace",
+		},
+		TargetPath: tmpDir,
+		Readonly:   true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wait.PollUntil(time.Second, func() (done bool, err error) {
+		files, err := store.ReadFiles("test-vol")
+		if errors.Is(err, storage.ErrNotFound) || len(files) <= 1 {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if !reflect.DeepEqual(files["ca"], []byte("ca bytes")) {
+			return false, fmt.Errorf("unexpected CA data: %v", files["ca"])
+		}
+		if !reflect.DeepEqual(files["cert"], []byte("certificate bytes")) {
+			return false, fmt.Errorf("unexpected certificate data: %v", files["cert"])
+		}
+		return true, nil
+	}, ctx.Done()); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestFailsIfNotReadyToRequest_ContinueOnNotReadyDisabled(t *testing.T) {
+	store := storage.NewMemoryFS()
+	clock := fakeclock.NewFakeClock(time.Now())
+
+	opts, cl, stop := testutil.RunTestDriver(t, testutil.DriverOptions{
+		Store:              store,
+		Clock:              clock,
+		ContinueOnNotReady: false,
+		ReadyToRequest: func(meta metadata.Metadata) bool {
+			return false
+		},
+		GeneratePrivateKey: func(meta metadata.Metadata) (crypto.PrivateKey, error) {
+			return nil, nil
+		},
+		GenerateRequest: func(meta metadata.Metadata) (*manager.CertificateRequestBundle, error) {
+			return &manager.CertificateRequestBundle{
+				Namespace: "certificaterequest-namespace",
+			}, nil
+		},
+		SignRequest: func(meta metadata.Metadata, key crypto.PrivateKey, request *x509.CertificateRequest) (csr []byte, err error) {
+			return []byte{}, nil
+		},
+		WriteKeypair: func(meta metadata.Metadata, key crypto.PrivateKey, chain []byte, ca []byte) error {
+			store.WriteFiles(meta, map[string][]byte{
+				"ca":   ca,
+				"cert": chain,
+			})
+			nextIssuanceTime := clock.Now().Add(time.Hour)
+			meta.NextIssuanceTime = &nextIssuanceTime
+			return store.WriteMetadata(meta.VolumeID, meta)
+		},
+	})
+	defer stop()
+
+	// Setup a routine to issue/sign the request IF it is created
+	stopCh := make(chan struct{})
+	go testutil.IssueAllRequests(t, opts.Client, "certificaterequest-namespace", stopCh, []byte("certificate bytes"), []byte("ca bytes"))
+	defer close(stopCh)
+
+	tmpDir, err := os.MkdirTemp("", "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	_, err = cl.NodePublishVolume(ctx, &csi.NodePublishVolumeRequest{
+		VolumeId: "test-vol",
+		VolumeContext: map[string]string{
+			"csi.storage.k8s.io/ephemeral":     "true",
+			"csi.storage.k8s.io/pod.name":      "the-pod-name",
+			"csi.storage.k8s.io/pod.namespace": "the-pod-namespace",
+		},
+		TargetPath: tmpDir,
+		Readonly:   true,
+	})
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Errorf("Expected timeout to be returned from NodePublishVolume but got: %v", err)
+	}
+
+	files, err := store.ReadFiles("test-vol")
+	if err != nil {
+		t.Errorf("failed to read files: %v", err)
+	}
+	if len(files["ca"]) > 0 {
+		t.Errorf("unexpected CA data: %v", files["ca"])
+	}
+	if len(files["cert"]) > 0 {
+		t.Errorf("unexpected certificate data: %v", files["cert"])
+	}
+}

--- a/test/util/testutil.go
+++ b/test/util/testutil.go
@@ -53,11 +53,13 @@ type DriverOptions struct {
 
 	NodeID               string
 	MaxRequestsPerVolume int
+	ContinueOnNotReady   bool
 
 	GeneratePrivateKey manager.GeneratePrivateKeyFunc
 	GenerateRequest    manager.GenerateRequestFunc
 	SignRequest        manager.SignRequestFunc
 	WriteKeypair       manager.WriteKeypairFunc
+	ReadyToRequest     manager.ReadyToRequestFunc
 }
 
 func RunTestDriver(t *testing.T, opts DriverOptions) (DriverOptions, csi.NodeClient, func()) {
@@ -117,15 +119,17 @@ func RunTestDriver(t *testing.T, opts DriverOptions) (DriverOptions, csi.NodeCli
 		GenerateRequest:      opts.GenerateRequest,
 		SignRequest:          opts.SignRequest,
 		WriteKeypair:         opts.WriteKeypair,
+		ReadyToRequest:       opts.ReadyToRequest,
 	})
 
 	d := driver.NewWithListener(lis, *opts.Log, driver.Options{
-		DriverName:    "driver-name",
-		DriverVersion: "v0.0.1",
-		NodeID:        opts.NodeID,
-		Store:         opts.Store,
-		Mounter:       opts.Mounter,
-		Manager:       m,
+		DriverName:         "driver-name",
+		DriverVersion:      "v0.0.1",
+		NodeID:             opts.NodeID,
+		Store:              opts.Store,
+		Mounter:            opts.Mounter,
+		Manager:            m,
+		ContinueOnNotReady: opts.ContinueOnNotReady,
 	})
 
 	// start the driver


### PR DESCRIPTION
This will help facilitate https://github.com/cert-manager/csi-driver/issues/17 and any other uses where we want to permit the pod to startup even if the CSI driver is not yet ready.

This feature comes with the caveat that user applications/pods MUST be designed to tolerate certificate/private key data not being available when the pod first starts up (as the driver will no longer block pod startup until the volume _is_ ready to request a certificate).
