### PR TITLE
Include Pod UID on CertificateRequest resources

### DIFF
--- a/internal/api/consts.go
+++ b/internal/api/consts.go
@@ -19,4 +19,5 @@ package api
 const (
 	NodeIDHashLabelKey   = "csi.cert-manager.io/node-id-hash"
 	VolumeIDHashLabelKey = "csi.cert-manager.io/volume-id-hash"
+	PodUIDLabelKey       = "csi.cert-manager.io/pod-uid"
 )

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -408,6 +408,7 @@ func (m *Manager) submitRequest(ctx context.Context, meta metadata.Metadata, csr
 			Labels: map[string]string{
 				internalapi.NodeIDHashLabelKey:   m.nodeNameHash,
 				internalapi.VolumeIDHashLabelKey: internalapiutil.HashIdentifier(meta.VolumeID),
+				internalapi.PodUIDLabelKey:       meta.VolumeContext["csi.storage.k8s.io/pod.uid"],
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{


### PR DESCRIPTION
This commit adds an additional label to the generated CertificateRequest
resources that includes the UID of the Pod that initiated the request via
the csi-driver implementation. The Pod UID is taken from the volume context
in the same way that is used to created the owner references.

Adding this label adds increased queryablility to see which pod generated
which certificate request. Internally at Jetstack, we want a way to monitor
unused certificates, so this label will help us in checking the specific pod.

It could be that some third party tool adds additional owner references to the
CertificateRequest resource, so this label (providing it isn't changed by another
third party) will give insight into the specific pod making the request.

Related to https://github.com/cert-manager/csi-driver/pull/102

Signed-off-by: David Bond <davidsbond93@gmail.com>