### PR TITLE
Use a passed through context to manager issue function

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -243,8 +243,7 @@ type Manager struct {
 }
 
 // issue will step through the entire issuance flow for a volume.
-func (m *Manager) issue(volumeID string) error {
-	ctx := context.TODO()
+func (m *Manager) issue(ctx context.Context, volumeID string) error {
 	log := m.log.WithValues("volume_id", volumeID)
 	log.Info("Processing issuance")
 
@@ -512,7 +511,7 @@ func (m *Manager) ManageVolume(volumeID string) error {
 						Cap: time.Minute,
 					}, func() (bool, error) {
 						log.Info("Triggering new issuance")
-						if err := m.issue(volumeID); err != nil {
+						if err := m.issue(ctx, volumeID); err != nil {
 							log.Error(err, "Failed to issue certificate, retrying after applying exponential backoff")
 							return false, nil
 						}


### PR DESCRIPTION
It is not clear to me why a TODO context is being used for the issuing function. It seems clear to me that we would want to use the context which is cancelled when the stop channel is closed.

PR passes that context through to `issue`.

/assign @munnerz