### PR TITLE
Default renewal time to halfway through certificates lifetime

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -404,7 +404,7 @@ func (m *Manager) issue(ctx context.Context, volumeID string) error {
 		return fmt.Errorf("waiting for request: %w", err)
 	}
 
-	// Default the renewal time to be halfway through the certificate's duration.
+	// Default the renewal time to be 2/3rds through the certificate's duration.
 	// The implementation's writeKeypair function may override this value before
 	// writing to the storage layer.
 	block, _ := pem.Decode(req.Status.Certificate)
@@ -413,8 +413,8 @@ func (m *Manager) issue(ctx context.Context, volumeID string) error {
 		return fmt.Errorf("parsing issued certificate: %w", err)
 	}
 	duration := crt.NotAfter.Sub(crt.NotBefore)
-	midpoint := crt.NotBefore.Add(duration / 2)
-	meta.NextIssuanceTime = &midpoint
+	renewalPoint := crt.NotBefore.Add(duration * (2 / 3))
+	meta.NextIssuanceTime = &renewalPoint
 
 	if err := m.writeKeypair(meta, key, req.Status.Certificate, req.Status.CA); err != nil {
 		return fmt.Errorf("writing keypair: %w", err)

--- a/test/integration/ready_to_request_test.go
+++ b/test/integration/ready_to_request_test.go
@@ -81,7 +81,7 @@ func Test_CompletesIfNotReadyToRequest_ContinueOnNotReadyEnabled(t *testing.T) {
 
 	// Setup a routine to issue/sign the request IF it is created
 	stopCh := make(chan struct{})
-	go testutil.IssueAllRequests(t, opts.Client, "certificaterequest-namespace", stopCh, []byte("certificate bytes"), []byte("ca bytes"))
+	go testutil.IssueAllRequests(t, opts.Client, "certificaterequest-namespace", stopCh, selfSignedExampleCertificate, []byte("ca bytes"))
 	defer close(stopCh)
 
 	tmpDir, err := os.MkdirTemp("", "*")
@@ -116,7 +116,7 @@ func Test_CompletesIfNotReadyToRequest_ContinueOnNotReadyEnabled(t *testing.T) {
 		if !reflect.DeepEqual(files["ca"], []byte("ca bytes")) {
 			return false, fmt.Errorf("unexpected CA data: %v", files["ca"])
 		}
-		if !reflect.DeepEqual(files["cert"], []byte("certificate bytes")) {
+		if !reflect.DeepEqual(files["cert"], selfSignedExampleCertificate) {
 			return false, fmt.Errorf("unexpected certificate data: %v", files["cert"])
 		}
 		return true, nil
@@ -161,7 +161,7 @@ func TestFailsIfNotReadyToRequest_ContinueOnNotReadyDisabled(t *testing.T) {
 
 	// Setup a routine to issue/sign the request IF it is created
 	stopCh := make(chan struct{})
-	go testutil.IssueAllRequests(t, opts.Client, "certificaterequest-namespace", stopCh, []byte("certificate bytes"), []byte("ca bytes"))
+	go testutil.IssueAllRequests(t, opts.Client, "certificaterequest-namespace", stopCh, selfSignedExampleCertificate, []byte("ca bytes"))
 	defer close(stopCh)
 	tmpDir, err := os.MkdirTemp("", "*")
 	if err != nil {


### PR DESCRIPTION
Since #35, we now rely on the next issuance time being set to properly 'resume' monitoring certificates after a driver restart.

Whilst we have always informed implementors to set the NextIssuanceTime field during their own `writeKeypair` implementation, we don't actually set this field in the core library.

This PR changes the issuance routine to explicitly default the NextIssuanceTime to be halfway through a certificate's lifetime. Implementors are free to override this default in their own `writeKeypair` function (and likely will/do). This serves as a default to avoid invalid/broken states from occurring (e.g. a certificate has been fully issued but the nextIssuanceTime is never set).