### PR TITLE
Add more exhaustive unit testing for manager

### DIFF
--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -2,18 +2,282 @@ package manager
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	testpkg "github.com/cert-manager/cert-manager/pkg/controller/test"
 	"github.com/go-logr/logr/testr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	coretesting "k8s.io/client-go/testing"
 
 	internalapi "github.com/cert-manager/csi-lib/internal/api"
 	internalapiutil "github.com/cert-manager/csi-lib/internal/api/util"
+	"github.com/cert-manager/csi-lib/metadata"
+	"github.com/cert-manager/csi-lib/storage"
+	testutil "github.com/cert-manager/csi-lib/test/util"
 )
+
+func TestManager_ManageVolumeImmediate_issueOnceAndSucceed(t *testing.T) {
+	ctx := context.Background()
+
+	opts := newDefaultTestOptions(t)
+	m, err := NewManager(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup a goroutine to issue one CertificateRequest
+	stopCh := make(chan struct{})
+	go testutil.IssueOneRequest(t, opts.Client, defaultTestNamespace, stopCh, selfSignedExampleCertificate, []byte("ca bytes"))
+	defer close(stopCh)
+
+	// Register a new volume with the metadata store
+	store := opts.MetadataReader.(storage.Interface)
+	meta := metadata.Metadata{
+		VolumeID:   "vol-id",
+		TargetPath: "/fake/path",
+	}
+	store.RegisterMetadata(meta)
+	// Ensure we stop managing the volume after the test
+	defer func() {
+		store.RemoveVolume(meta.VolumeID)
+		m.UnmanageVolume(meta.VolumeID)
+	}()
+
+	// Attempt to issue the certificate & put it under management
+	managed, err := m.ManageVolumeImmediate(ctx, meta.VolumeID)
+	if !managed {
+		t.Errorf("expected management to have started, but it did not")
+	}
+	if err != nil {
+		t.Errorf("expected no error from ManageVolumeImmediate but got: %v", err)
+	}
+
+	// Assert the certificate is under management
+	if !m.IsVolumeReady(meta.VolumeID) {
+		t.Errorf("expected volume to be marked as Ready but it is not")
+	}
+}
+
+func TestManager_PropagatesRequestConditionMessages(t *testing.T) {
+	tests := []struct {
+		approved      string
+		ready         string
+		expectedError string
+	}{
+		{
+			approved:      "",
+			ready:         "",
+			expectedError: "waiting for request: request \"certificaterequest-name\" has not yet been approved by approval plugin",
+		},
+		{
+			approved:      "",
+			ready:         "pending",
+			expectedError: "waiting for request: request \"certificaterequest-name\" has not yet been approved by approval plugin",
+		},
+		{
+			approved:      "",
+			ready:         "failed",
+			expectedError: "waiting for request: request \"certificaterequest-name\" has failed: failed",
+		},
+		//"pending approval, ready == true": {}
+		{
+			approved:      "denied",
+			ready:         "",
+			expectedError: "waiting for request: request \"certificaterequest-name\" has been denied by the approval plugin: denied",
+		},
+		{
+			approved:      "denied",
+			ready:         "pending",
+			expectedError: "waiting for request: request \"certificaterequest-name\" has been denied by the approval plugin: denied",
+		},
+		{
+			approved:      "denied",
+			ready:         "failed",
+			expectedError: "waiting for request: request \"certificaterequest-name\" has been denied by the approval plugin: denied",
+		},
+		//"denied, ready == true": {},
+		{
+			approved:      "approved",
+			ready:         "",
+			expectedError: "waiting for request: request \"certificaterequest-name\" has no ready condition",
+		},
+		{
+			approved:      "approved",
+			ready:         "pending",
+			expectedError: "waiting for request: request \"certificaterequest-name\" is pending: pending",
+		},
+		{
+			approved:      "approved",
+			ready:         "failed",
+			expectedError: "waiting for request: request \"certificaterequest-name\" has failed: failed",
+		},
+		//"approved, ready == true": {},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("approval=%q, readiness=%q", test.approved, test.ready), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+			defer cancel()
+
+			opts := newDefaultTestOptions(t)
+			m, err := NewManager(opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer m.Stop()
+			m.requestNameGenerator = func() string { return "certificaterequest-name" }
+
+			// build conditions to set based on test configuration
+			var conditions []cmapi.CertificateRequestCondition
+			switch test.approved {
+			case "":
+			case "approved":
+				conditions = append(conditions, cmapi.CertificateRequestCondition{Type: cmapi.CertificateRequestConditionApproved, Status: cmmeta.ConditionTrue, Reason: "SetByTest", Message: "approved"})
+			case "denied":
+				conditions = append(conditions, cmapi.CertificateRequestCondition{Type: cmapi.CertificateRequestConditionDenied, Status: cmmeta.ConditionTrue, Reason: "SetByTest", Message: "denied"})
+			}
+			switch test.ready {
+			case "":
+			case "pending":
+				conditions = append(conditions, cmapi.CertificateRequestCondition{Type: cmapi.CertificateRequestConditionReady, Status: cmmeta.ConditionFalse, Reason: cmapi.CertificateRequestReasonPending, Message: "pending"})
+			case "failed":
+				conditions = append(conditions, cmapi.CertificateRequestCondition{Type: cmapi.CertificateRequestConditionReady, Status: cmmeta.ConditionFalse, Reason: cmapi.CertificateRequestReasonFailed, Message: "failed"})
+			}
+			// Automatically set the request to be approved & pending once created
+			go testutil.SetCertificateRequestConditions(ctx, t, opts.Client, defaultTestNamespace, conditions...)
+
+			// Register a new volume with the metadata store
+			store := opts.MetadataReader.(storage.Interface)
+			meta := metadata.Metadata{
+				VolumeID:   "vol-id",
+				TargetPath: "/fake/path",
+			}
+			store.RegisterMetadata(meta)
+			// Ensure we stop managing the volume after the test
+			defer func() {
+				store.RemoveVolume(meta.VolumeID)
+				m.UnmanageVolume(meta.VolumeID)
+			}()
+
+			// Attempt to issue the certificate & put it under management
+			managed, err := m.ManageVolumeImmediate(ctx, meta.VolumeID)
+			if !managed {
+				t.Errorf("expected volume to still be managed after failure")
+			}
+			if err == nil {
+				t.Errorf("expected to get an error from ManageVolumeImmediate")
+			}
+			if err.Error() != test.expectedError {
+				t.Errorf("expected '%s' but got: %s", test.expectedError, err.Error())
+			}
+		})
+	}
+}
+
+func TestManager_ResumesManagementOfExistingVolumes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancel()
+
+	store := storage.NewMemoryFS()
+	opts := defaultTestOptions(t, Options{MetadataReader: store})
+
+	m, err := NewManager(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m.requestNameGenerator = func() string { return "certificaterequest-name" }
+	// Automatically issue the request once created
+	go testutil.IssueOneRequest(t, opts.Client, defaultTestNamespace, ctx.Done(), selfSignedExampleCertificate, []byte("ca bytes"))
+
+	// Register a new volume with the metadata store
+	meta := metadata.Metadata{
+		VolumeID:   "vol-id",
+		TargetPath: "/fake/path",
+	}
+	_, err = store.RegisterMetadata(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attempt to issue the certificate & put it under management
+	managed, err := m.ManageVolumeImmediate(ctx, meta.VolumeID)
+	if !managed {
+		t.Fatalf("expected volume to be managed")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Shutdown the manager
+	m.Stop()
+
+	m, err = NewManager(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Stop()
+
+	if !m.IsVolumeReady(meta.VolumeID) {
+		t.Errorf("expected volume to be monitored & ready but it is not")
+	}
+}
+
+func TestManager_ManageVolume_beginsManagingAndProceedsIfNotReady(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := newDefaultTestOptions(t)
+	m, err := NewManager(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Register a new volume with the metadata store
+	store := opts.MetadataReader.(storage.Interface)
+	meta := metadata.Metadata{
+		VolumeID:   "vol-id",
+		TargetPath: "/fake/path",
+	}
+	store.RegisterMetadata(meta)
+	// Ensure we stop managing the volume after the test
+	defer func() {
+		store.RemoveVolume(meta.VolumeID)
+		m.UnmanageVolume(meta.VolumeID)
+	}()
+
+	// Put the certificate under management
+	managed := m.ManageVolume(meta.VolumeID)
+	if !managed {
+		t.Errorf("expected management to have started, but it did not")
+	}
+
+	if err := wait.PollUntilWithContext(ctx, time.Millisecond*500, func(ctx context.Context) (done bool, err error) {
+		reqs, err := opts.Client.CertmanagerV1().CertificateRequests("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(reqs.Items) == 1 {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Errorf("failed waiting for CertificateRequest to exist: %v", err)
+	}
+
+	// Assert the certificate is under management - it won't be ready as no issuer has issued the certificate
+	if m.IsVolumeReady(meta.VolumeID) {
+		t.Errorf("expected volume to not be Ready but it is")
+	}
+	if _, ok := m.managedVolumes[meta.VolumeID]; !ok {
+		t.Errorf("expected volume to be part of managedVolumes map but it is not")
+	}
+}
 
 func TestManager_cleanupStaleRequests(t *testing.T) {
 

--- a/manager/utils_test.go
+++ b/manager/utils_test.go
@@ -1,0 +1,113 @@
+package manager
+
+import (
+	"crypto"
+	"crypto/x509"
+	"k8s.io/utils/clock"
+	"math"
+	"testing"
+	"time"
+
+	cmfake "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
+	"github.com/go-logr/logr/testr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	fakeclock "k8s.io/utils/clock/testing"
+
+	"github.com/cert-manager/csi-lib/metadata"
+	"github.com/cert-manager/csi-lib/storage"
+)
+
+// Default namespace name used when constructing test fixtures.
+var defaultTestNamespace = "default-testns-name"
+
+// Self signed certificate valid for 'example.com' (and probably expired by the time this is read).
+// This is used during test fixtures as the test driver attempts to parse the PEM certificate data,
+// so we can't just use any random bytes.
+var selfSignedExampleCertificate = []byte(`-----BEGIN CERTIFICATE-----
+MIICxjCCAa6gAwIBAgIRAI0W8ofWt2fD+J7Cha10KwwwDQYJKoZIhvcNAQELBQAw
+ADAeFw0yMjA5MTMwODI0MDBaFw0yMjEyMTIwODI0MDBaMAAwggEiMA0GCSqGSIb3
+DQEBAQUAA4IBDwAwggEKAoIBAQDR2ktXXbuJPZhudwfbwiYuKjb7BfehfuRZtme4
+HNvIhf0ABavuK4uRlKAKXRt1SZWMzm6P7NpTSOHjlxoBluZKFsgQbtNYYC8cBOMr
+1TuU9UwAD6U4Lw+obWQppwaEYIifdSVWUqphRT2I6EJONEB9ZUr0gHMKJ2sjl163
+WseSDyjPHkEM3wmpHpdDfYjNQRZ9sKB4J4/R8maW1IPpzltbryNQMfVJCYA7SjvJ
+KZK5cyhabqNVeBhjBSp+UczQVrJ4ruam3i4LFUbu7DVJ/60C8knhFxGJZ5uaPbOd
+eStraFOp50S3JbSpymq2m8c02ZsunUYiWCXGoh/UqrfYViVVAgMBAAGjOzA5MA4G
+A1UdDwEB/wQEAwIFoDAMBgNVHRMBAf8EAjAAMBkGA1UdEQEB/wQPMA2CC2V4YW1w
+bGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQCkAvvWIUgdpuukL8nqX3850FtHl8r9
+I9oCra4Tv7fxsggFMhIbrVUjzE0NCB/kTjr5j/KFid9TFtbBo7bvYRKI1Qx12y28
+CTvY1y5BqFN/lT917B+8lrWyvxsbtQ0Xhvj9JgbLhGQutR4J+ee1sKZTPqP/sSGl
+PfY1JD5zWYWXWweLAR9hTp62SL6KVfsTT77jw0foehEKxfJbZY2wkdUS5GFMB8/a
+KQ+2l7/qPU8XL8whXEsifoJJ+U66v3cfsH0PIhTV2JKhagljdTVf333JBD/z49qv
+vnEIALrtIClFU6D/mTU5wyHhN29llwfjUgJrmYWqoWTZSiwGS6YmZpry
+-----END CERTIFICATE-----`)
+
+func newDefaultTestOptions(t *testing.T) Options {
+	return defaultTestOptions(t, Options{})
+}
+
+func defaultTestOptions(t *testing.T, opts Options) Options {
+	var store storage.Interface
+	if opts.MetadataReader == nil {
+		store = storage.NewMemoryFS()
+		opts.MetadataReader = store
+	} else {
+		store = opts.MetadataReader.(storage.Interface)
+	}
+	if opts.Clock == nil {
+		opts.Clock = fakeclock.NewFakeClock(time.Now())
+	}
+	if opts.Log == nil {
+		log := testr.New(t)
+		opts.Log = &log
+	}
+	if opts.Client == nil {
+		opts.Client = cmfake.NewSimpleClientset()
+	}
+	if opts.NodeID == "" {
+		opts.NodeID = "test-node-id"
+	}
+	if opts.GeneratePrivateKey == nil {
+		opts.GeneratePrivateKey = nothingGeneratePrivateKey
+	}
+	if opts.GenerateRequest == nil {
+		opts.GenerateRequest = generateRequestInNamespace(defaultTestNamespace)
+	}
+	if opts.SignRequest == nil {
+		opts.SignRequest = nothingSignRequest
+	}
+	if opts.WriteKeypair == nil {
+		opts.WriteKeypair = persistingWriteKeypair(store, opts.Clock)
+	}
+	if opts.RenewalBackoffConfig == nil {
+		opts.RenewalBackoffConfig = &wait.Backoff{Steps: math.MaxInt32} // backoff is always 0s for speedy tests
+	}
+	return opts
+}
+
+func nothingGeneratePrivateKey(meta metadata.Metadata) (crypto.PrivateKey, error) {
+	return nil, nil
+}
+
+func generateRequestInNamespace(ns string) GenerateRequestFunc {
+	return func(meta metadata.Metadata) (*CertificateRequestBundle, error) {
+		return &CertificateRequestBundle{
+			Namespace: ns,
+		}, nil
+	}
+}
+
+func nothingSignRequest(meta metadata.Metadata, key crypto.PrivateKey, request *x509.CertificateRequest) (csr []byte, err error) {
+	return []byte{}, nil
+}
+
+func persistingWriteKeypair(store storage.Interface, clock clock.Clock) WriteKeypairFunc {
+	return func(meta metadata.Metadata, key crypto.PrivateKey, chain []byte, ca []byte) error {
+		store.WriteFiles(meta, map[string][]byte{
+			"ca":   ca,
+			"cert": chain,
+		})
+		nextIssuanceTime := clock.Now().Add(time.Hour)
+		meta.NextIssuanceTime = &nextIssuanceTime
+		return store.WriteMetadata(meta.VolumeID, meta)
+	}
+}

--- a/test/driver/driver_testing.go
+++ b/test/driver/driver_testing.go
@@ -19,6 +19,10 @@ package driver
 import (
 	"crypto"
 	"crypto/x509"
+	"math"
+	"net"
+	"testing"
+
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	fakeclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -28,9 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/mount-utils"
 	"k8s.io/utils/clock"
-	"math"
-	"net"
-	"testing"
 
 	"github.com/cert-manager/csi-lib/driver"
 	"github.com/cert-manager/csi-lib/manager"
@@ -38,7 +39,7 @@ import (
 	"github.com/cert-manager/csi-lib/storage"
 )
 
-type DriverOptions struct {
+type Options struct {
 	Clock   clock.Clock
 	Store   storage.Interface
 	Log     *logr.Logger
@@ -56,7 +57,7 @@ type DriverOptions struct {
 	ReadyToRequest     manager.ReadyToRequestFunc
 }
 
-func RunTestDriver(t *testing.T, opts DriverOptions) (DriverOptions, csi.NodeClient, func()) {
+func Run(t *testing.T, opts Options) (Options, csi.NodeClient, func()) {
 	if opts.Log == nil {
 		logger := logrtesting.NewTestLogger(t)
 		opts.Log = &logger

--- a/test/driver/driver_testing.go
+++ b/test/driver/driver_testing.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"crypto"
+	"crypto/x509"
+	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	fakeclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/go-logr/logr"
+	logrtesting "github.com/go-logr/logr/testing"
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/mount-utils"
+	"k8s.io/utils/clock"
+	"math"
+	"net"
+	"testing"
+
+	"github.com/cert-manager/csi-lib/driver"
+	"github.com/cert-manager/csi-lib/manager"
+	"github.com/cert-manager/csi-lib/metadata"
+	"github.com/cert-manager/csi-lib/storage"
+)
+
+type DriverOptions struct {
+	Clock   clock.Clock
+	Store   storage.Interface
+	Log     *logr.Logger
+	Client  cmclient.Interface
+	Mounter mount.Interface
+
+	NodeID               string
+	MaxRequestsPerVolume int
+	ContinueOnNotReady   bool
+
+	GeneratePrivateKey manager.GeneratePrivateKeyFunc
+	GenerateRequest    manager.GenerateRequestFunc
+	SignRequest        manager.SignRequestFunc
+	WriteKeypair       manager.WriteKeypairFunc
+	ReadyToRequest     manager.ReadyToRequestFunc
+}
+
+func RunTestDriver(t *testing.T, opts DriverOptions) (DriverOptions, csi.NodeClient, func()) {
+	if opts.Log == nil {
+		logger := logrtesting.NewTestLogger(t)
+		opts.Log = &logger
+	}
+	if opts.Clock == nil {
+		opts.Clock = &clock.RealClock{}
+	}
+	if opts.Store == nil {
+		opts.Store = storage.NewMemoryFS()
+	}
+	if opts.Client == nil {
+		opts.Client = fakeclient.NewSimpleClientset()
+	}
+	if opts.Mounter == nil {
+		opts.Mounter = mount.NewFakeMounter(nil)
+	}
+	if opts.NodeID == "" {
+		opts.NodeID = "test-node"
+	}
+	if opts.GeneratePrivateKey == nil {
+		opts.GeneratePrivateKey = func(_ metadata.Metadata) (crypto.PrivateKey, error) {
+			return nil, nil
+		}
+	}
+	if opts.GenerateRequest == nil {
+		opts.GenerateRequest = func(_ metadata.Metadata) (*manager.CertificateRequestBundle, error) {
+			return &manager.CertificateRequestBundle{}, nil
+		}
+	}
+	if opts.SignRequest == nil {
+		opts.SignRequest = func(_ metadata.Metadata, _ crypto.PrivateKey, _ *x509.CertificateRequest) ([]byte, error) {
+			return []byte{}, nil
+		}
+	}
+	if opts.WriteKeypair == nil {
+		opts.WriteKeypair = func(_ metadata.Metadata, _ crypto.PrivateKey, _ []byte, _ []byte) error {
+			return nil
+		}
+	}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to setup test listener: %v", err)
+	}
+
+	m := manager.NewManagerOrDie(manager.Options{
+		Client:               opts.Client,
+		MetadataReader:       opts.Store,
+		Clock:                opts.Clock,
+		Log:                  opts.Log,
+		NodeID:               opts.NodeID,
+		MaxRequestsPerVolume: opts.MaxRequestsPerVolume,
+		GeneratePrivateKey:   opts.GeneratePrivateKey,
+		GenerateRequest:      opts.GenerateRequest,
+		SignRequest:          opts.SignRequest,
+		WriteKeypair:         opts.WriteKeypair,
+		ReadyToRequest:       opts.ReadyToRequest,
+		RenewalBackoffConfig: &wait.Backoff{Steps: math.MaxInt32}, // don't actually wait (i.e. set all backoff times to 0)
+	})
+
+	d := driver.NewWithListener(lis, *opts.Log, driver.Options{
+		DriverName:         "driver-name",
+		DriverVersion:      "v0.0.1",
+		NodeID:             opts.NodeID,
+		Store:              opts.Store,
+		Mounter:            opts.Mounter,
+		Manager:            m,
+		ContinueOnNotReady: opts.ContinueOnNotReady,
+	})
+
+	// start the driver
+	go func() {
+		if err := d.Run(); err != nil {
+			t.Fatalf("failed running driver: %v", err)
+		}
+	}()
+
+	// create a client connection to the grpc server
+	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+
+	return opts, csi.NewNodeClient(conn), func() {
+		m.Stop()
+		if err := conn.Close(); err != nil {
+			t.Fatalf("error closing client connection: %v", err)
+		}
+		d.Stop()
+		lis.Close()
+	}
+}

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -43,7 +43,7 @@ import (
 func TestIssuesCertificate(t *testing.T) {
 	store := storage.NewMemoryFS()
 	clock := fakeclock.NewFakeClock(time.Now())
-	opts, cl, stop := testdriver.RunTestDriver(t, testdriver.DriverOptions{
+	opts, cl, stop := testdriver.Run(t, testdriver.Options{
 		Store: store,
 		Clock: clock,
 		GeneratePrivateKey: func(meta metadata.Metadata) (crypto.PrivateKey, error) {
@@ -108,7 +108,7 @@ func TestManager_CleansUpOldRequests(t *testing.T) {
 	store := storage.NewMemoryFS()
 	clock := fakeclock.NewFakeClock(time.Now())
 
-	opts, cl, stop := testdriver.RunTestDriver(t, testdriver.DriverOptions{
+	opts, cl, stop := testdriver.Run(t, testdriver.Options{
 		Store:                store,
 		Clock:                clock,
 		MaxRequestsPerVolume: 1,

--- a/test/integration/issuance_test.go
+++ b/test/integration/issuance_test.go
@@ -36,13 +36,14 @@ import (
 	"github.com/cert-manager/csi-lib/manager"
 	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/cert-manager/csi-lib/storage"
+	testdriver "github.com/cert-manager/csi-lib/test/driver"
 	testutil "github.com/cert-manager/csi-lib/test/util"
 )
 
 func TestIssuesCertificate(t *testing.T) {
 	store := storage.NewMemoryFS()
 	clock := fakeclock.NewFakeClock(time.Now())
-	opts, cl, stop := testutil.RunTestDriver(t, testutil.DriverOptions{
+	opts, cl, stop := testdriver.RunTestDriver(t, testdriver.DriverOptions{
 		Store: store,
 		Clock: clock,
 		GeneratePrivateKey: func(meta metadata.Metadata) (crypto.PrivateKey, error) {
@@ -107,7 +108,7 @@ func TestManager_CleansUpOldRequests(t *testing.T) {
 	store := storage.NewMemoryFS()
 	clock := fakeclock.NewFakeClock(time.Now())
 
-	opts, cl, stop := testutil.RunTestDriver(t, testutil.DriverOptions{
+	opts, cl, stop := testdriver.RunTestDriver(t, testdriver.DriverOptions{
 		Store:                store,
 		Clock:                clock,
 		MaxRequestsPerVolume: 1,

--- a/test/integration/ready_to_request_test.go
+++ b/test/integration/ready_to_request_test.go
@@ -45,7 +45,7 @@ func Test_CompletesIfNotReadyToRequest_ContinueOnNotReadyEnabled(t *testing.T) {
 	clock := fakeclock.NewFakeClock(time.Now())
 
 	calls := 0
-	opts, cl, stop := testdriver.RunTestDriver(t, testdriver.DriverOptions{
+	opts, cl, stop := testdriver.Run(t, testdriver.Options{
 		Store:              store,
 		Clock:              clock,
 		ContinueOnNotReady: true,
@@ -130,7 +130,7 @@ func TestFailsIfNotReadyToRequest_ContinueOnNotReadyDisabled(t *testing.T) {
 	store := storage.NewMemoryFS()
 	clock := fakeclock.NewFakeClock(time.Now())
 
-	opts, cl, stop := testdriver.RunTestDriver(t, testdriver.DriverOptions{
+	opts, cl, stop := testdriver.Run(t, testdriver.Options{
 		Store:              store,
 		Clock:              clock,
 		ContinueOnNotReady: false,

--- a/test/integration/ready_to_request_test.go
+++ b/test/integration/ready_to_request_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cert-manager/csi-lib/manager"
 	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/cert-manager/csi-lib/storage"
+	testdriver "github.com/cert-manager/csi-lib/test/driver"
 	testutil "github.com/cert-manager/csi-lib/test/util"
 )
 
@@ -44,7 +45,7 @@ func Test_CompletesIfNotReadyToRequest_ContinueOnNotReadyEnabled(t *testing.T) {
 	clock := fakeclock.NewFakeClock(time.Now())
 
 	calls := 0
-	opts, cl, stop := testutil.RunTestDriver(t, testutil.DriverOptions{
+	opts, cl, stop := testdriver.RunTestDriver(t, testdriver.DriverOptions{
 		Store:              store,
 		Clock:              clock,
 		ContinueOnNotReady: true,
@@ -129,7 +130,7 @@ func TestFailsIfNotReadyToRequest_ContinueOnNotReadyDisabled(t *testing.T) {
 	store := storage.NewMemoryFS()
 	clock := fakeclock.NewFakeClock(time.Now())
 
-	opts, cl, stop := testutil.RunTestDriver(t, testutil.DriverOptions{
+	opts, cl, stop := testdriver.RunTestDriver(t, testdriver.DriverOptions{
 		Store:              store,
 		Clock:              clock,
 		ContinueOnNotReady: false,


### PR DESCRIPTION
This adds a selection of new unit tests for the manager, testing behaviour for handling failed requests as well as tests for the regular issuance path.

We also need to add tests to ensure *renewals* are triggered when expected - a similar pattern as defined here can be used for that, but for now I thought I'd get this in before the PR grows further 😄 

/assign @JoshVanL 