### PR TITLE
Replace use of testify in manager/util in favour of stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/container-storage-interface/spec v1.6.0
 	github.com/go-logr/logr v1.2.3
 	github.com/kubernetes-csi/csi-lib-utils v0.11.0
-	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20220615171555-694bf12d69de
 	google.golang.org/grpc v1.47.0
 	k8s.io/apimachinery v0.23.4
@@ -30,7 +29,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/manager/util/tokenrequest_test.go
+++ b/manager/util/tokenrequest_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package util
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	"k8s.io/client-go/rest"
 
 	"github.com/cert-manager/csi-lib/metadata"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_restConfigForMetadataTokenRequestEmptyAud(t *testing.T) {
@@ -131,8 +131,12 @@ func Test_restConfigForMetadataTokenRequestEmptyAud(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			restConfig, gotErr := restConfigForMetadataTokenRequestEmptyAud(baseRestConfig)(metadata.Metadata{VolumeContext: test.volumeContext})
-			assert.Equal(t, test.expErr, gotErr != nil, "%v", gotErr)
-			assert.Equal(t, test.expRestConfig, restConfig)
+			if test.expErr != (gotErr != nil) {
+				t.Errorf("expected error %t but got %v", test.expErr, gotErr)
+			}
+			if !reflect.DeepEqual(test.expRestConfig, restConfig) {
+				t.Errorf("expected rest config %v but got %v", test.expRestConfig, restConfig)
+			}
 		})
 	}
 }


### PR DESCRIPTION
See: https://github.com/cert-manager/csi-lib/pull/37#discussion_r969744685

We have decided the not use the testify assert and require libraries for testing.

PR replaces use in `manager/utils` for stdlib.

/assign @munnerz 