### PR TITLE
Add timeout to renewal issuance logic

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -90,7 +90,7 @@ type Options struct {
 	// IssueRenewalTimeout defines timeout value for each issue() call in renewal process
 	IssueRenewalTimeout time.Duration
 	// IssuePollInterval defines an interval time for each subroutine call (check CSR status) within issue() function
-	// Note, the issuePollInterval should be less than renewalIssueTimeout
+	// Note, the IssuePollInterval should be less than IssueRenewalTimeout
 	IssuePollInterval time.Duration
 }
 
@@ -159,6 +159,10 @@ func NewManager(opts Options) (*Manager, error) {
 	if opts.IssuePollInterval == 0 {
 		opts.IssuePollInterval = time.Second
 	}
+	if opts.IssuePollInterval >= opts.IssueRenewalTimeout {
+		return nil, errors.New("IssuePollInterval should be less than IssueRenewalTimeout")
+	}
+	// Check IssuePollInterval is less than IssueRenewalTimeout
 	if len(opts.NodeID) == 0 {
 		return nil, errors.New("NodeID must be set")
 	}
@@ -307,7 +311,7 @@ type Manager struct {
 	// issueRenewalTimeout defines timeout value for each issue() call in renewal process
 	issueRenewalTimeout time.Duration
 	// issuePollInterval defines an interval time for each subroutine call (check CSR status) within issue() function
-	// Note, the issuePollInterval should be less than renewalIssueTimeout
+	// Note, the issuePollInterval should be less than issueRenewalTimeout
 	issuePollInterval time.Duration
 
 	// requestNameGenerator generates a new random name for a certificaterequest object

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -293,7 +293,6 @@ func TestManager_ManageVolume_exponentialBackOffRetryOnIssueErrors(t *testing.T)
 	expBackOffJitter := 0.0 // No jitter to the 'duration', so we could calculate number of retries easily
 	expBackOffSteps := 100  // The maximum number of backoff attempts
 	issueRenewalTimeout := expBackOffDuration
-	issuePollInterval := issueRenewalTimeout / 10
 
 	// Expected number of retries in each expBackOff cycle :=
 	// 				⌈log base expBackOffFactor of (expBackOffCap/expBackOffDuration)⌉
@@ -314,14 +313,13 @@ func TestManager_ManageVolume_exponentialBackOffRetryOnIssueErrors(t *testing.T)
 		Jitter:   expBackOffJitter,
 		Steps:    expBackOffSteps,
 	}
-	opts.IssueRenewalTimeout = issueRenewalTimeout
-	opts.IssuePollInterval = issuePollInterval
 	opts.ReadyToRequest = func(meta metadata.Metadata) (bool, string) {
 		// ReadyToRequest will be called by issue()
 		atomic.AddInt32(&numOfRetries, 1) // run in a goroutine, thus increment it atomically
 		return true, ""                   // AlwaysReadyToRequest
 	}
 	m, err := NewManager(opts)
+	m.issueRenewalTimeout = issueRenewalTimeout
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/driver/driver_testing.go
+++ b/test/driver/driver_testing.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"net"
 	"testing"
-	"time"
 
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	fakeclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
@@ -117,8 +116,6 @@ func Run(t *testing.T, opts Options) (Options, csi.NodeClient, func()) {
 		WriteKeypair:         opts.WriteKeypair,
 		ReadyToRequest:       opts.ReadyToRequest,
 		RenewalBackoffConfig: &wait.Backoff{Steps: math.MaxInt32}, // don't actually wait (i.e. set all backoff times to 0)
-		IssueRenewalTimeout:  time.Second,                         // timeout issue renewal call in a second
-		IssuePollInterval:    100 * time.Millisecond,              // check CSR status every 0.1s during issue call
 	})
 
 	d := driver.NewWithListener(lis, *opts.Log, driver.Options{

--- a/test/driver/driver_testing.go
+++ b/test/driver/driver_testing.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net"
 	"testing"
+	"time"
 
 	cmclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	fakeclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
@@ -116,6 +117,8 @@ func Run(t *testing.T, opts Options) (Options, csi.NodeClient, func()) {
 		WriteKeypair:         opts.WriteKeypair,
 		ReadyToRequest:       opts.ReadyToRequest,
 		RenewalBackoffConfig: &wait.Backoff{Steps: math.MaxInt32}, // don't actually wait (i.e. set all backoff times to 0)
+		IssueRenewalTimeout:  time.Second,                         // timeout issue renewal call in a second
+		IssuePollInterval:    100 * time.Millisecond,              // check CSR status every 0.1s during issue call
 	})
 
 	d := driver.NewWithListener(lis, *opts.Log, driver.Options{


### PR DESCRIPTION
Add an internal parameter to control issue() call during renewal:
- issueRenewalTimeout: default 60s to align with NodePublishVolume timeout value

This fix prevents inifite loop in a single issue() call when CertificateRequest is in a pending state.

fixes: #45