### PR TITLE
Retry pending request when issue is called

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -835,10 +835,10 @@ func isX509CertificateRequestSemanticEqual(cr1, cr2 *x509.CertificateRequest) bo
 		return false
 	}
 
+	// Note, Subject.Names[] contains all "parsed" attributes from Subject's fields.
+	// If cr1 is a signed version of cr2, reflect.DeepEqual(cr1.Subject, cr2.Subject) could be false.
 	return cr1.Version == cr2.Version &&
-		cr1.SignatureAlgorithm == cr2.SignatureAlgorithm &&
-		cr1.PublicKeyAlgorithm == cr2.PublicKeyAlgorithm &&
-		reflect.DeepEqual(cr1.Subject, cr2.Subject) &&
+		cr1.Subject.String() == cr2.Subject.String() &&
 		reflect.DeepEqual(cr1.Extensions, cr2.Extensions) &&
 		reflect.DeepEqual(cr1.ExtraExtensions, cr2.ExtraExtensions) &&
 		reflect.DeepEqual(cr1.DNSNames, cr2.DNSNames) &&

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -3,6 +3,8 @@ package manager
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -16,7 +18,6 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
-	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -439,7 +440,7 @@ func TestManager_issue_reuseLastPendingRequest(t *testing.T) {
 
 	opts := newDefaultTestOptions(t)
 	opts.GeneratePrivateKey = func(meta metadata.Metadata) (crypto.PrivateKey, error) {
-		return pki.GenerateECPrivateKey(256) // generate an EC-P-256 private key
+		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader) // generate an EC-P-256 private key
 	}
 	opts.GenerateRequest = func(meta metadata.Metadata) (*CertificateRequestBundle, error) {
 		// generate a CSR bundle in defaultTestNamespace, and its CN is specified in meta.VolumeContext["CN"] field


### PR DESCRIPTION
If there is a pending request matches newly build csrBundle, reuse it instead of creating a new one.

fixes: #47