### PR TITLE
Fix default renewal time calculation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/container-storage-interface/spec v1.7.0
 	github.com/go-logr/logr v1.2.3
 	github.com/kubernetes-csi/csi-lib-utils v0.13.0
+	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.7.0
 	google.golang.org/grpc v1.53.0
 	k8s.io/apimachinery v0.26.1
@@ -44,6 +45,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.39.0 // indirect

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -95,7 +95,7 @@ type Options struct {
 // resume managing them if any already exist.
 func NewManager(opts Options) (*Manager, error) {
 	if opts.Client == nil {
-		return nil, errors.New("Client must be set")
+		return nil, errors.New("client must be set")
 	}
 	if opts.ClientForMetadata == nil {
 		opts.ClientForMetadata = func(_ metadata.Metadata) (cmclient.Interface, error) {
@@ -122,7 +122,7 @@ func NewManager(opts Options) (*Manager, error) {
 		}
 	}
 	if opts.Log == nil {
-		return nil, errors.New("Log must be set")
+		return nil, errors.New("log must be set")
 	}
 	if opts.MetadataReader == nil {
 		return nil, errors.New("MetadataReader must be set")

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -413,16 +413,13 @@ func (m *Manager) issue(ctx context.Context, volumeID string) error {
 		return fmt.Errorf("waiting for request: %w", err)
 	}
 
-	// Default the renewal time to be 2/3rds through the certificate's duration.
+	// Calculate the default next issuance time.
 	// The implementation's writeKeypair function may override this value before
 	// writing to the storage layer.
-	block, _ := pem.Decode(req.Status.Certificate)
-	crt, err := x509.ParseCertificate(block.Bytes)
+	renewalPoint, err := calculateNextIssuanceTime(req.Status.Certificate)
 	if err != nil {
-		return fmt.Errorf("parsing issued certificate: %w", err)
+		return fmt.Errorf("calculating next issuance time: %w", err)
 	}
-	duration := crt.NotAfter.Sub(crt.NotBefore)
-	renewalPoint := crt.NotBefore.Add(duration * (2 / 3))
 	meta.NextIssuanceTime = &renewalPoint
 
 	if err := m.writeKeypair(meta, key, req.Status.Certificate, req.Status.CA); err != nil {
@@ -721,4 +718,21 @@ func (m *Manager) Stop() {
 		close(stopCh)
 		delete(m.managedVolumes, k)
 	}
+}
+
+// calculateNextIssuanceTime will return the default time at which the certificate
+// should be renewed by the driver- 2/3rds through its lifetime (NotAfter -
+// NotBefore).
+func calculateNextIssuanceTime(chain []byte) (time.Time, error) {
+	block, _ := pem.Decode(chain)
+	crt, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parsing issued certificate: %w", err)
+	}
+
+	actualDuration := crt.NotAfter.Sub(crt.NotBefore)
+
+	renewBeforeNotAfter := actualDuration / 3
+
+	return crt.NotAfter.Add(-renewBeforeNotAfter), nil
 }


### PR DESCRIPTION
The default renewal time calculation had a bug [here](https://github.com/cert-manager/csi-lib/blob/main/manager/manager.go#L425)- `duration * (2/3)` would always be 0 (integer division) so the certs would always be renewed 'now'.

This did not actually affect cert-manager/csi-driver and cert-manager/csi-driver-spiffe as both had their own calculation of renewal time that was overriding this value see [here](https://github.com/cert-manager/csi-driver/blob/main/pkg/filestore/writer.go#L118) and [here](https://github.com/cert-manager/csi-driver-spiffe/blob/d71c5a9e6a465b3bb6ba4006879ffd84ecbd52e2/internal/csi/driver/util.go#L52).

The new function and test are adopted from the csi-driver/csi-driver-spiffe examples linked above.