### PR TITLE
manager: separate backoff for gate-pending vs issuance failures

### DIFF
--- a/manager/interfaces.go
+++ b/manager/interfaces.go
@@ -29,13 +29,16 @@ import (
 	"github.com/cert-manager/csi-lib/metadata"
 )
 
-// ErrNotReadyToRequest is returned by the renewal loop's issue() when
-// ReadyToRequestFunc reports the driver is not yet ready (a wait state, not a
-// failure). The renewal loop uses errors.Is to distinguish this from real
-// issuance errors (signer down, apiserver error, denial) and applies a
-// separate, faster backoff appropriate for waiting on pod state. Consumers
-// can also use errors.Is to surface this case in their own observability.
-var ErrNotReadyToRequest = errors.New("driver is not ready to request a certificate")
+// errNotReadyToRequest is returned by issue() when ReadyToRequestFunc reports
+// the driver is not yet ready (a wait state, not a failure). The renewal loop
+// uses errors.Is to distinguish this from real issuance errors (signer down,
+// apiserver error, denial) and applies a separate, faster backoff appropriate
+// for waiting on pod state.
+//
+// Kept unexported because issue() is unexported and no current consumer needs
+// to detect this case via errors.Is. Can be promoted to exported if a real
+// use case appears.
+var errNotReadyToRequest = errors.New("driver is not ready to request a certificate")
 
 // GeneratePrivateKeyFunc returns a private key to be used for issuance of the
 // given request.

--- a/manager/interfaces.go
+++ b/manager/interfaces.go
@@ -19,6 +19,7 @@ package manager
 import (
 	"crypto"
 	"crypto/x509"
+	"errors"
 	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -27,6 +28,14 @@ import (
 
 	"github.com/cert-manager/csi-lib/metadata"
 )
+
+// ErrNotReadyToRequest is returned by the renewal loop's issue() when
+// ReadyToRequestFunc reports the driver is not yet ready (a wait state, not a
+// failure). The renewal loop uses errors.Is to distinguish this from real
+// issuance errors (signer down, apiserver error, denial) and applies a
+// separate, faster backoff appropriate for waiting on pod state. Consumers
+// can also use errors.Is to surface this case in their own observability.
+var ErrNotReadyToRequest = errors.New("driver is not ready to request a certificate")
 
 // GeneratePrivateKeyFunc returns a private key to be used for issuance of the
 // given request.

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -96,8 +96,10 @@ type Options struct {
 	// assign a pod IP), not a failure, and warrants a faster retry cadence than
 	// genuine issuance errors. The renewal loop selects between this backoff
 	// and RenewalBackoffConfig based on whether the issue() error wraps
-	// ErrNotReadyToRequest.
-	// If nil, defaults to: 1s base, factor 2.0, jitter 0.5, cap 10s.
+	// errNotReadyToRequest.
+	// If nil, defaults to: 1s base, factor 2.0, jitter 0.5, cap 10s, and
+	// Steps set to math.MaxInt32 so the backoff is effectively never reset
+	// except on a successful issuance.
 	GateBackoffConfig *wait.Backoff
 
 	// Metrics is used for exposing Prometheus metrics
@@ -448,7 +450,7 @@ func (m *Manager) issue(ctx context.Context, volumeID string) error {
 	}
 
 	if ready, reason := m.readyToRequest(meta); !ready {
-		return fmt.Errorf("%w for this volume: %s", ErrNotReadyToRequest, reason)
+		return fmt.Errorf("%w for this volume: %s", errNotReadyToRequest, reason)
 	}
 	key, err := m.generatePrivateKey(meta)
 	if err != nil {
@@ -857,7 +859,7 @@ func (m *Manager) startRenewalRoutine(volumeID string) (started bool) {
 
 // attemptIssuanceIfDue reads the volume's metadata and, if a new issuance is
 // due, calls issue() with a class-aware retry. Errors wrapping
-// ErrNotReadyToRequest (gate-pending wait state) use gateBackoffConfig; all
+// errNotReadyToRequest (gate-pending wait state) use gateBackoffConfig; all
 // other errors (signer failures, apiserver errors) use backoffConfig. Each
 // backoff is reset when the error class changes so a long run of one class
 // does not bleed into the other. Returns when issuance succeeds or ctx is
@@ -875,10 +877,6 @@ func (m *Manager) attemptIssuanceIfDue(ctx context.Context, log logr.Logger, vol
 	issuanceBackoff := m.backoffConfig
 	gateBackoff := m.gateBackoffConfig
 	for {
-		if ctx.Err() != nil {
-			return
-		}
-
 		log.Info("Triggering new issuance")
 		issueCtx, issueCancel := context.WithTimeout(ctx, m.issueRenewalTimeout)
 		err := m.issue(issueCtx, volumeID)
@@ -888,7 +886,7 @@ func (m *Manager) attemptIssuanceIfDue(ctx context.Context, log logr.Logger, vol
 		}
 
 		var delay time.Duration
-		if errors.Is(err, ErrNotReadyToRequest) {
+		if errors.Is(err, errNotReadyToRequest) {
 			log.V(4).Info("readiness gate not yet met, retrying with gate backoff", "error", err)
 			delay = gateBackoff.Step()
 			issuanceBackoff = m.backoffConfig

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -91,6 +91,15 @@ type Options struct {
 	// RenewalBackoffConfig configures the exponential backoff applied to certificate renewal failures.
 	RenewalBackoffConfig *wait.Backoff
 
+	// GateBackoffConfig configures the backoff applied when ReadyToRequestFunc
+	// returns false. This is an expected wait state (e.g. waiting for CNI to
+	// assign a pod IP), not a failure, and warrants a faster retry cadence than
+	// genuine issuance errors. The renewal loop selects between this backoff
+	// and RenewalBackoffConfig based on whether the issue() error wraps
+	// ErrNotReadyToRequest.
+	// If nil, defaults to: 1s base, factor 2.0, jitter 0.5, cap 10s.
+	GateBackoffConfig *wait.Backoff
+
 	// Metrics is used for exposing Prometheus metrics
 	Metrics *metrics.Metrics
 }
@@ -125,6 +134,18 @@ func NewManager(opts Options) (*Manager, error) {
 			Steps: math.MaxInt32,
 			// The maximum time between calls will be 5 minutes
 			Cap: time.Minute * 5,
+		}
+	}
+	if opts.GateBackoffConfig == nil {
+		// Gate-pending is a wait state, not a failure. Defaults are tuned for
+		// CNI-style gates that resolve in seconds — much faster than the
+		// signer-protective RenewalBackoffConfig defaults above.
+		opts.GateBackoffConfig = &wait.Backoff{
+			Duration: time.Second,
+			Factor:   2.0,
+			Jitter:   0.5,
+			Steps:    math.MaxInt32,
+			Cap:      time.Second * 10,
 		}
 	}
 	if opts.Log == nil {
@@ -259,6 +280,7 @@ func NewManager(opts Options) (*Manager, error) {
 		maxRequestsPerVolume: opts.MaxRequestsPerVolume,
 		nodeNameHash:         nodeNameHash,
 		backoffConfig:        *opts.RenewalBackoffConfig,
+		gateBackoffConfig:    *opts.GateBackoffConfig,
 		issueRenewalTimeout:  time.Second * 60, // issueRenewalTimeout set to align with NodePublishVolume timeout value
 		requestNameGenerator: func() string {
 			return string(uuid.NewUUID())
@@ -366,6 +388,11 @@ type Manager struct {
 	// backoffConfig configures the exponential backoff applied to certificate renewal failures.
 	backoffConfig wait.Backoff
 
+	// gateBackoffConfig configures the backoff applied when ReadyToRequestFunc
+	// returns false. Distinct from backoffConfig because gate-pending is a
+	// wait state, not a failure, and warrants faster retry.
+	gateBackoffConfig wait.Backoff
+
 	// issueRenewalTimeout defines timeout value for each issue() call in renewal process
 	issueRenewalTimeout time.Duration
 
@@ -421,7 +448,7 @@ func (m *Manager) issue(ctx context.Context, volumeID string) error {
 	}
 
 	if ready, reason := m.readyToRequest(meta); !ready {
-		return fmt.Errorf("driver is not ready to request a certificate for this volume: %v", reason)
+		return fmt.Errorf("%w for this volume: %s", ErrNotReadyToRequest, reason)
 	}
 	key, err := m.generatePrivateKey(meta)
 	if err != nil {
@@ -821,43 +848,67 @@ func (m *Manager) startRenewalRoutine(volumeID string) (started bool) {
 				// management of this volume has been stopped, exit the goroutine
 				return
 			case <-ticker.C:
-				meta, err := m.metadataReader.ReadMetadata(volumeID)
-				if err != nil {
-					log.Error(err, "Failed to read metadata")
-					continue
-				}
-
-				if meta.NextIssuanceTime == nil || m.clock.Now().After(*meta.NextIssuanceTime) {
-					// If issuing a certificate fails, we don't go around the outer for loop again (as we'd then be creating
-					// a new CertificateRequest every second).
-					// Instead, retry within the same iteration of the for loop and apply an exponential backoff.
-					// Because we pass ctx through to the 'wait' package, if the stopCh is closed/context is cancelled,
-					// we'll immediately stop waiting and 'continue' which will then hit the `case <-stopCh` case in the `select`.
-					if err := wait.ExponentialBackoffWithContext(ctx, m.backoffConfig, func(ctx context.Context) (bool, error) {
-						log.Info("Triggering new issuance")
-						issueCtx, issueCancel := context.WithTimeout(ctx, m.issueRenewalTimeout)
-						defer issueCancel()
-						if err := m.issue(issueCtx, volumeID); err != nil {
-							log.Error(err, "Failed to issue certificate, retrying after applying exponential backoff")
-							// Increase issue error count
-							if m.metrics != nil {
-								m.metrics.IncrementIssueErrorCountTotal(m.nodeNameHash, volumeID)
-							}
-							return false, nil
-						}
-						return true, nil
-					}); err != nil {
-						if wait.Interrupted(err) {
-							continue
-						}
-						// this should never happen as the function above never actually returns errors
-						log.Error(err, "unexpected error")
-					}
-				}
+				m.attemptIssuanceIfDue(ctx, log, volumeID)
 			}
 		}
 	}()
 	return true
+}
+
+// attemptIssuanceIfDue reads the volume's metadata and, if a new issuance is
+// due, calls issue() with a class-aware retry. Errors wrapping
+// ErrNotReadyToRequest (gate-pending wait state) use gateBackoffConfig; all
+// other errors (signer failures, apiserver errors) use backoffConfig. Each
+// backoff is reset when the error class changes so a long run of one class
+// does not bleed into the other. Returns when issuance succeeds or ctx is
+// cancelled.
+func (m *Manager) attemptIssuanceIfDue(ctx context.Context, log logr.Logger, volumeID string) {
+	meta, err := m.metadataReader.ReadMetadata(volumeID)
+	if err != nil {
+		log.Error(err, "Failed to read metadata")
+		return
+	}
+	if meta.NextIssuanceTime != nil && !m.clock.Now().After(*meta.NextIssuanceTime) {
+		return
+	}
+
+	issuanceBackoff := m.backoffConfig
+	gateBackoff := m.gateBackoffConfig
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		log.Info("Triggering new issuance")
+		issueCtx, issueCancel := context.WithTimeout(ctx, m.issueRenewalTimeout)
+		err := m.issue(issueCtx, volumeID)
+		issueCancel()
+		if err == nil {
+			return
+		}
+
+		var delay time.Duration
+		if errors.Is(err, ErrNotReadyToRequest) {
+			log.V(4).Info("readiness gate not yet met, retrying with gate backoff", "error", err)
+			delay = gateBackoff.Step()
+			issuanceBackoff = m.backoffConfig
+		} else {
+			log.Error(err, "Failed to issue certificate, retrying after applying exponential backoff")
+			if m.metrics != nil {
+				m.metrics.IncrementIssueErrorCountTotal(m.nodeNameHash, volumeID)
+			}
+			delay = issuanceBackoff.Step()
+			gateBackoff = m.gateBackoffConfig
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
 }
 
 // ManageVolume will initiate management of data for the given volumeID. It will not wait for an initial certificate

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -18,12 +18,16 @@ package manager
 
 import (
 	"context"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"math"
 	"math/big"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -387,6 +391,159 @@ func TestManager_ManageVolume_exponentialBackOffRetryOnIssueErrors(t *testing.T)
 	if actualNumOfRetries != expectNumOfRetries {
 		t.Errorf("expect %g retries, but got %g", expectNumOfRetries, actualNumOfRetries)
 	}
+}
+
+// TestManager_attemptIssuanceIfDue_backoffByErrorClass exercises the retry
+// helper's selection between gateBackoffConfig (for ReadyToRequestFunc
+// returning false) and RenewalBackoffConfig (for issuance errors). Each
+// scenario scripts a sequence of per-issue() outcomes; the test asserts the
+// helper completes within a deadline that would be exceeded if the wrong
+// backoff were applied to the wrong error class.
+//
+// Calling attemptIssuanceIfDue directly avoids the renewal goroutine's 1-second
+// ticker tax that an end-to-end ManageVolume test would pay, so each scenario
+// runs in single-digit milliseconds. The integration path is already exercised
+// by TestManager_ManageVolume_beginsManagingAndProceedsIfNotReady and
+// TestManager_ManageVolume_exponentialBackOffRetryOnIssueErrors.
+func TestManager_attemptIssuanceIfDue_backoffByErrorClass(t *testing.T) {
+	type outcome int
+	const (
+		success outcome = iota
+		notReady
+		signFailure
+	)
+
+	const slow = 500 * time.Millisecond
+	const fast = 1 * time.Millisecond
+
+	tests := map[string]struct {
+		// One entry per issue() call. Runs out → subsequent attempts succeed.
+		script         []outcome
+		renewalBackoff *wait.Backoff
+		gateBackoff    *wait.Backoff
+		// wantUnder is the wall-clock budget. Set so a misrouted backoff would
+		// blow it (gate using renewalBackoff or vice versa).
+		wantUnder time.Duration
+	}{
+		"gate-pending uses gate backoff not renewal backoff": {
+			// 3 notReady × renewalBackoff would be ≥ 1.5s; gateBackoff makes it ≪100ms.
+			script:         []outcome{notReady, notReady, notReady},
+			renewalBackoff: &wait.Backoff{Duration: slow, Factor: 1.0, Steps: math.MaxInt32, Cap: slow},
+			gateBackoff:    &wait.Backoff{Duration: fast, Factor: 1.0, Steps: math.MaxInt32, Cap: fast},
+			wantUnder:      100 * time.Millisecond,
+		},
+		"issuance failure uses renewal backoff not gate backoff": {
+			// 2 signFailure × gateBackoff would be ≥ 1s; renewalBackoff makes it ≪100ms.
+			script:         []outcome{signFailure, signFailure},
+			renewalBackoff: &wait.Backoff{Duration: fast, Factor: 1.0, Steps: math.MaxInt32, Cap: fast},
+			gateBackoff:    &wait.Backoff{Duration: slow, Factor: 1.0, Steps: math.MaxInt32, Cap: slow},
+			wantUnder:      100 * time.Millisecond,
+		},
+		"alternating classes do not bleed: gate-pending then signer error then gate-pending recovers": {
+			// If either backoff failed to reset on class change, a later run of
+			// the same class would inherit a grown delay and exceed the budget.
+			script:         []outcome{notReady, notReady, signFailure, notReady, notReady},
+			renewalBackoff: &wait.Backoff{Duration: fast, Factor: 1.0, Steps: math.MaxInt32, Cap: fast},
+			gateBackoff:    &wait.Backoff{Duration: fast, Factor: 1.0, Steps: math.MaxInt32, Cap: fast},
+			wantUnder:      100 * time.Millisecond,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// readyToRequest advances a shared per-issue() index; signRequest
+			// reads the same index so both stubs agree on which scripted
+			// outcome applies to the current issue() call.
+			var idx int32 = -1
+			readyToRequest := func(_ metadata.Metadata) (bool, string) {
+				i := int(atomic.AddInt32(&idx, 1))
+				if i < len(tc.script) && tc.script[i] == notReady {
+					return false, "gate not yet met"
+				}
+				return true, ""
+			}
+			signRequest := func(_ metadata.Metadata, _ crypto.PrivateKey, _ *x509.CertificateRequest) ([]byte, error) {
+				i := int(atomic.LoadInt32(&idx))
+				if i < len(tc.script) && tc.script[i] == signFailure {
+					return nil, fmt.Errorf("simulated signer error")
+				}
+				return nothingSignRequest(metadata.Metadata{}, nil, nil)
+			}
+
+			opts := newDefaultTestOptions(t)
+			opts.ReadyToRequest = readyToRequest
+			opts.SignRequest = signRequest
+			opts.RenewalBackoffConfig = tc.renewalBackoff
+			opts.GateBackoffConfig = tc.gateBackoff
+
+			m, err := NewManager(opts)
+			require.NoError(t, err)
+			m.issueRenewalTimeout = 100 * time.Millisecond
+
+			store := opts.MetadataReader.(storage.Interface)
+			meta := metadata.Metadata{VolumeID: "vol-id", TargetPath: "/fake/path"}
+			_, err = store.RegisterMetadata(meta)
+			require.NoError(t, err)
+			defer func() {
+				_ = store.RemoveVolume(meta.VolumeID)
+			}()
+
+			ctx := t.Context()
+			// Mark the eventual CertificateRequest as Issued so the call to
+			// m.issue() returns instead of polling forever for completion.
+			go testutil.IssueOneRequest(ctx, t, opts.Client, defaultTestNamespace, selfSignedExampleCertificate, []byte("ca bytes"))
+
+			log := testr.New(t)
+			start := time.Now()
+			m.attemptIssuanceIfDue(ctx, log, meta.VolumeID)
+			elapsed := time.Since(start)
+
+			assert.Less(t, elapsed, tc.wantUnder,
+				"attemptIssuanceIfDue took %s; expected <%s (likely wrong backoff applied to the wrong error class)", elapsed, tc.wantUnder)
+
+			reqs, listErr := opts.Client.CertmanagerV1().CertificateRequests("").List(ctx, metav1.ListOptions{})
+			require.NoError(t, listErr)
+			assert.Len(t, reqs.Items, 1, "expected exactly one CertificateRequest after successful issuance")
+		})
+	}
+}
+
+// TestManager_issue_wrapsErrNotReadyToRequest verifies issue() wraps the
+// readyToRequest false return with the exported sentinel, so the renewal loop
+// (and consumers) can detect gate-pending via errors.Is.
+func TestManager_issue_wrapsErrNotReadyToRequest(t *testing.T) {
+	opts := newDefaultTestOptions(t)
+	opts.ReadyToRequest = func(_ metadata.Metadata) (bool, string) {
+		return false, "gate not yet met"
+	}
+
+	m, err := NewManager(opts)
+	require.NoError(t, err)
+
+	store := opts.MetadataReader.(storage.Interface)
+	meta := metadata.Metadata{VolumeID: "vol-id", TargetPath: "/fake/path"}
+	_, err = store.RegisterMetadata(meta)
+	require.NoError(t, err)
+
+	err = m.issue(t.Context(), meta.VolumeID)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotReadyToRequest), "got %v", err)
+	assert.Contains(t, err.Error(), "gate not yet met")
+}
+
+// TestManager_NewManager_defaultsGateBackoffConfig locks in the chosen
+// defaults for GateBackoffConfig so changes to the defaults are explicit.
+func TestManager_NewManager_defaultsGateBackoffConfig(t *testing.T) {
+	opts := newDefaultTestOptions(t)
+	opts.GateBackoffConfig = nil
+
+	m, err := NewManager(opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, time.Second, m.gateBackoffConfig.Duration)
+	assert.Equal(t, 2.0, m.gateBackoffConfig.Factor)
+	assert.Equal(t, 0.5, m.gateBackoffConfig.Jitter)
+	assert.Equal(t, 10*time.Second, m.gateBackoffConfig.Cap)
 }
 
 func TestManager_cleanupStaleRequests(t *testing.T) {

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -508,10 +508,10 @@ func TestManager_attemptIssuanceIfDue_backoffByErrorClass(t *testing.T) {
 	}
 }
 
-// TestManager_issue_wrapsErrNotReadyToRequest verifies issue() wraps the
-// readyToRequest false return with the exported sentinel, so the renewal loop
-// (and consumers) can detect gate-pending via errors.Is.
-func TestManager_issue_wrapsErrNotReadyToRequest(t *testing.T) {
+// TestManager_issue_wrapsNotReadyError verifies issue() wraps the
+// readyToRequest false return with the errNotReadyToRequest sentinel so the
+// renewal loop can detect gate-pending via errors.Is.
+func TestManager_issue_wrapsNotReadyError(t *testing.T) {
 	opts := newDefaultTestOptions(t)
 	opts.ReadyToRequest = func(_ metadata.Metadata) (bool, string) {
 		return false, "gate not yet met"
@@ -527,7 +527,7 @@ func TestManager_issue_wrapsErrNotReadyToRequest(t *testing.T) {
 
 	err = m.issue(t.Context(), meta.VolumeID)
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrNotReadyToRequest), "got %v", err)
+	assert.True(t, errors.Is(err, errNotReadyToRequest), "got %v", err)
 	assert.Contains(t, err.Error(), "gate not yet met")
 }
 

--- a/manager/utils_test.go
+++ b/manager/utils_test.go
@@ -97,6 +97,9 @@ func defaultTestOptions(t *testing.T, opts Options) Options {
 	if opts.RenewalBackoffConfig == nil {
 		opts.RenewalBackoffConfig = &wait.Backoff{Steps: math.MaxInt32} // backoff is always 0s for speedy tests
 	}
+	if opts.GateBackoffConfig == nil {
+		opts.GateBackoffConfig = &wait.Backoff{Steps: math.MaxInt32} // backoff is always 0s for speedy tests
+	}
 	return opts
 }
 


### PR DESCRIPTION
Implements #234

When `ReadyToRequestFunc` returns false, the renewal loop was synthesising an error and routing it through the same exponential backoff used for genuine issuance failures (30s base, 5min cap). That cadence is correct for protecting a sick signer from a thundering herd, but wrong for a wait state where the underlying condition (CNI assigning a pod IP, a controller flipping a pod condition) typically resolves in seconds.

  This PR:
  - Adds an exported `ErrNotReadyToRequest` sentinel.
  - Adds `GateBackoffConfig` to `manager.Options` (nil defaults to 1s base, factor 2.0, jitter 0.5, cap 10s).
  - Wraps the readyToRequest false return inside `issue()` with the sentinel.
  - Extracts the renewal loop's retry into `attemptIssuanceIfDue`, which routes by error class via `errors.Is` and resets each backoff when the class changes so they decay independently.

## Tests
  Added unit tests
  All existing tests pass (no regression)

## Backwards compatibility
  Consumers using `AlwaysReadyToRequest` (the default) never enter the gate-pending path, so behaviour is identical. Consumers with a custom `ReadyToRequestFunc` (e.g. cert-manager/csi-driver post-#638) inherit the new default gate backoff automatically, which is the intended fix.