### PR TITLE
fix: redact ServiceAccount bearer tokens from log output

### DIFF
--- a/driver/server.go
+++ b/driver/server.go
@@ -23,10 +23,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/go-logr/logr"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 	"google.golang.org/grpc"
+	protopb "google.golang.org/protobuf/proto"
 )
 
 type GRPCServer struct {
@@ -102,7 +104,8 @@ func parseEndpoint(ep string) (string, string, error) {
 
 func loggingInterceptor(log logr.Logger) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		log := log.WithValues("rpc_method", info.FullMethod, "request", protosanitizer.StripSecrets(req))
+		sanitized := protosanitizer.StripSecrets(redactSATokens(req))
+		log := log.WithValues("rpc_method", info.FullMethod, "request", sanitized)
 		log.V(3).Info("handling request")
 		resp, err := handler(ctx, req)
 		if err != nil {
@@ -112,4 +115,20 @@ func loggingInterceptor(log logr.Logger) grpc.UnaryServerInterceptor {
 		}
 		return resp, err
 	}
+}
+
+// redactSATokens returns a copy of req with the ServiceAccount bearer token
+// redacted (replaced with "[REDACTED]") in the VolumeContext of a
+// NodePublishVolumeRequest. All other request types are returned as-is. The original request is never mutated.
+func redactSATokens(req any) any {
+	npvr, ok := req.(*csi.NodePublishVolumeRequest)
+	if !ok {
+		return req
+	}
+	if _, hasToken := npvr.GetVolumeContext()[metadata.SATokenVolumeContextKey]; !hasToken {
+		return req
+	}
+	sanitized := protopb.Clone(npvr).(*csi.NodePublishVolumeRequest)
+	sanitized.VolumeContext[metadata.SATokenVolumeContextKey] = "[REDACTED]"
+	return sanitized
 }

--- a/driver/server_test.go
+++ b/driver/server_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+	"k8s.io/klog/v2/ktesting"
+
+	"github.com/cert-manager/csi-lib/metadata"
+)
+
+// testToken is a realistic kubelet-injected serviceAccount.tokens blob.
+// "secret" is a distinctive substring used throughout to detect leaks.
+const testToken = `{"":{"token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.secret","expirationTimestamp":"2099-01-01T00:00:00Z"}}`
+
+func requireNoTokenInOutput(t *testing.T, output string) {
+	t.Helper()
+	for _, needle := range []string{"secret", "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9"} {
+		if strings.Contains(output, needle) {
+			t.Errorf("SA token leaked into log output (found %q):\n%s", needle, output)
+		}
+	}
+}
+
+// TestRedactSATokens_NodePublishVolumeRequest verifies that redactSATokens
+// replaces the SA token in VolumeContext with "[REDACTED]" without mutating
+// the original request or dropping unrelated context keys.
+func TestRedactSATokens_NodePublishVolumeRequest(t *testing.T) {
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId: "vol-123",
+		VolumeContext: map[string]string{
+			metadata.SATokenVolumeContextKey:         testToken,
+			"csi.storage.k8s.io/pod.name":            "my-pod",
+			"csi.storage.k8s.io/serviceAccount.name": "my-sa",
+		},
+	}
+
+	result := redactSATokens(req)
+
+	sanitized, ok := result.(*csi.NodePublishVolumeRequest)
+	if !ok {
+		t.Fatalf("redactSATokens returned %T, want *csi.NodePublishVolumeRequest", result)
+	}
+	if sanitized.VolumeContext[metadata.SATokenVolumeContextKey] != "[REDACTED]" {
+		t.Errorf("got %q, want [REDACTED]", sanitized.VolumeContext[metadata.SATokenVolumeContextKey])
+	}
+	if sanitized.VolumeContext["csi.storage.k8s.io/pod.name"] != "my-pod" {
+		t.Error("non-sensitive volume context keys were dropped")
+	}
+	if sanitized.VolumeId != "vol-123" {
+		t.Error("VolumeId was altered")
+	}
+	// Original must not be mutated.
+	if req.VolumeContext[metadata.SATokenVolumeContextKey] != testToken {
+		t.Error("redactSATokens mutated the original request")
+	}
+}
+
+// TestRedactSATokens_noToken_returnsOriginal verifies that redactSATokens
+// returns the original pointer unchanged when no SA token key is present,
+// avoiding unnecessary allocations on the common path.
+func TestRedactSATokens_noToken_returnsOriginal(t *testing.T) {
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:      "vol-456",
+		VolumeContext: map[string]string{"csi.storage.k8s.io/pod.name": "other-pod"},
+	}
+	if redactSATokens(req) != req {
+		t.Error("expected original pointer when no SA token key present")
+	}
+}
+
+// TestRedactSATokens_nonNodePublishRequest_returnsOriginal verifies that
+// redactSATokens is a no-op for request types other than
+// NodePublishVolumeRequest, which carry no SA token.
+func TestRedactSATokens_nonNodePublishRequest_returnsOriginal(t *testing.T) {
+	req := &csi.NodeUnpublishVolumeRequest{VolumeId: "vol-789"}
+	if redactSATokens(req) != req {
+		t.Error("expected original pointer for non-NodePublishVolumeRequest type")
+	}
+}
+
+// TestLoggingInterceptor_errorPath_noTokenLeaked covers Sink #3 (error level,
+// default verbosity). This fires on any NodePublishVolume handler failure,
+// which includes routine conditions such as readOnly not set or issuer timeout.
+func TestLoggingInterceptor_errorPath_noTokenLeaked(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true)))
+	underlier, _ := logger.GetSink().(ktesting.Underlier)
+	interceptor := loggingInterceptor(logger)
+
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId: "vol-123",
+		VolumeContext: map[string]string{
+			metadata.SATokenVolumeContextKey: testToken,
+			"csi.storage.k8s.io/pod.name":    "my-pod",
+		},
+	}
+
+	handler := func(_ context.Context, _ any) (any, error) {
+		return nil, fmt.Errorf("simulated handler error")
+	}
+	info := &grpc.UnaryServerInfo{FullMethod: "/csi.v1.Node/NodePublishVolume"}
+
+	_, _ = interceptor(context.Background(), req, info, handler)
+
+	output := underlier.GetBuffer().String()
+	if !strings.Contains(output, "failed processing request") {
+		t.Fatalf("expected error log line to be present; got:\n%s", output)
+	}
+	requireNoTokenInOutput(t, output)
+}
+
+// TestLoggingInterceptor_successPath_noTokenLeaked covers Sink #1 (V(3) entry)
+// and the V(5) completion line; neither should carry the raw token.
+func TestLoggingInterceptor_successPath_noTokenLeaked(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true)))
+	underlier, _ := logger.GetSink().(ktesting.Underlier)
+	interceptor := loggingInterceptor(logger)
+
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId: "vol-456",
+		VolumeContext: map[string]string{
+			metadata.SATokenVolumeContextKey: testToken,
+		},
+	}
+
+	handler := func(_ context.Context, _ any) (any, error) {
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+	info := &grpc.UnaryServerInfo{FullMethod: "/csi.v1.Node/NodePublishVolume"}
+
+	_, _ = interceptor(context.Background(), req, info, handler)
+
+	requireNoTokenInOutput(t, underlier.GetBuffer().String())
+}
+
+// TestLoggingInterceptor_metadataLog_noTokenLeaked covers Sink #2 (V(2) in
+// manager.go). A caller that logs a Metadata value via a logr.Logger must
+// not see the raw token in the output.
+func TestLoggingInterceptor_metadataLog_noTokenLeaked(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true)))
+	underlier, _ := logger.GetSink().(ktesting.Underlier)
+
+	meta := metadata.Metadata{
+		VolumeID:   "vol-789",
+		TargetPath: "/var/lib/kubelet/pods/abc/volumes/tls",
+		VolumeContext: map[string]string{
+			metadata.SATokenVolumeContextKey: testToken,
+			"csi.storage.k8s.io/pod.name":    "my-pod",
+		},
+	}
+
+	// Reproduce the exact call in manager/manager.go:398.
+	logger.V(2).Info("Read metadata", "metadata", meta)
+
+	output := underlier.GetBuffer().String()
+	if !strings.Contains(output, "Read metadata") {
+		t.Fatalf("log line not captured; got:\n%s", output)
+	}
+	requireNoTokenInOutput(t, output)
+}
+
+// TestLoggingInterceptor_originalRequestUnmutated verifies that the handler
+// still receives the unmodified request (including the real token) so that
+// the driver can use it for token-request authentication.
+func TestLoggingInterceptor_originalRequestUnmutated(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.DefaultConfig)
+	interceptor := loggingInterceptor(logger)
+
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId: "vol-123",
+		VolumeContext: map[string]string{
+			metadata.SATokenVolumeContextKey: testToken,
+		},
+	}
+
+	var receivedToken string
+	handler := func(_ context.Context, raw any) (any, error) {
+		r := raw.(*csi.NodePublishVolumeRequest)
+		receivedToken = r.VolumeContext[metadata.SATokenVolumeContextKey]
+		return &csi.NodePublishVolumeResponse{}, nil
+	}
+	info := &grpc.UnaryServerInfo{FullMethod: "/csi.v1.Node/NodePublishVolume"}
+
+	_, _ = interceptor(context.Background(), req, info, handler)
+
+	if receivedToken != testToken {
+		t.Errorf("handler received mutated token %q, want original", receivedToken)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.81.1
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
 	k8s.io/klog/v2 v2.140.0
@@ -64,7 +65,6 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 // indirect
-	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/manager/util/tokenrequest.go
+++ b/manager/util/tokenrequest.go
@@ -103,9 +103,9 @@ func EmptyAudienceTokenFromMetadata(meta metadata.Metadata) (string, error) {
 		Token string `json:"token"`
 	})
 
-	tokensJson, ok := meta.VolumeContext["csi.storage.k8s.io/serviceAccount.tokens"]
+	tokensJson, ok := meta.VolumeContext[metadata.SATokenVolumeContextKey]
 	if !ok {
-		return "", errors.New("'csi.storage.k8s.io/serviceAccount.tokens' not present in volume context, driver likely doesn't have token requests enabled")
+		return "", errors.New("'" + metadata.SATokenVolumeContextKey + "' not present in volume context, driver likely doesn't have token requests enabled")
 	}
 
 	err := json.Unmarshal([]byte(tokensJson), &tokens)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -17,10 +17,17 @@ limitations under the License.
 package metadata
 
 import (
+	"maps"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
+
+// SATokenVolumeContextKey is the VolumeContext key under which kubelet injects
+// the mounting pod's bound ServiceAccount bearer token when the CSIDriver
+// declares spec.tokenRequests. The value is sensitive and must never appear in
+// log output.
+const SATokenVolumeContextKey = "csi.storage.k8s.io/serviceAccount.tokens"
 
 // Metadata contains metadata about a particular CSI volume and its contents.
 // It is safe to be serialised to disk for later reading (e.g. upon renewals).
@@ -52,4 +59,20 @@ func FromNodePublishVolumeRequest(request *csi.NodePublishVolumeRequest) Metadat
 		VolumeContext:    request.GetVolumeContext(),
 		VolumeMountGroup: request.GetVolumeCapability().GetMount().GetVolumeMountGroup(),
 	}
+}
+
+// MarshalLog implements logr.Marshaler so that structured loggers redact the
+// SA bearer token from VolumeContext before emitting a log entry. Without
+// this, log.Info("...", "metadata", meta) would print the live
+// ServiceAccount token injected by kubelet.
+func (m Metadata) MarshalLog() any {
+	if _, ok := m.VolumeContext[SATokenVolumeContextKey]; !ok {
+		return m
+	}
+	redacted := m
+	vc := make(map[string]string, len(m.VolumeContext))
+	maps.Copy(vc, m.VolumeContext)
+	vc[SATokenVolumeContextKey] = "[REDACTED]"
+	redacted.VolumeContext = vc
+	return redacted
 }

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const testToken = `{"":{"token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.secret","expirationTimestamp":"2099-01-01T00:00:00Z"}}`
+
+// TestMetadata_MarshalLog_redactsSAToken verifies that MarshalLog replaces the
+// SA token with "[REDACTED]" without dropping other context keys or mutating
+// the original Metadata value.
+func TestMetadata_MarshalLog_redactsSAToken(t *testing.T) {
+	m := Metadata{
+		VolumeID:   "vol-123",
+		TargetPath: "/var/lib/kubelet/pods/abc/volumes",
+		VolumeContext: map[string]string{
+			SATokenVolumeContextKey:                  testToken,
+			"csi.storage.k8s.io/pod.name":            "my-pod",
+			"csi.storage.k8s.io/serviceAccount.name": "my-sa",
+		},
+	}
+
+	logged := m.MarshalLog()
+	loggedMeta, ok := logged.(Metadata)
+	if !ok {
+		t.Fatalf("MarshalLog returned %T, want Metadata", logged)
+	}
+	if loggedMeta.VolumeContext[SATokenVolumeContextKey] != "[REDACTED]" {
+		t.Errorf("token not redacted: got %q", loggedMeta.VolumeContext[SATokenVolumeContextKey])
+	}
+	if loggedMeta.VolumeContext["csi.storage.k8s.io/pod.name"] != "my-pod" {
+		t.Error("non-sensitive keys were dropped")
+	}
+	// Original must not be mutated.
+	if m.VolumeContext[SATokenVolumeContextKey] != testToken {
+		t.Error("MarshalLog mutated the original Metadata")
+	}
+}
+
+// TestMetadata_MarshalLog_noToken_passthrough verifies that MarshalLog returns
+// the Metadata unchanged when no SA token key is present, ensuring there is no
+// unintended key loss on the common (token-free) path.
+func TestMetadata_MarshalLog_noToken_passthrough(t *testing.T) {
+	m := Metadata{
+		VolumeID:      "vol-456",
+		VolumeContext: map[string]string{"csi.storage.k8s.io/pod.name": "other-pod"},
+	}
+	logged := m.MarshalLog()
+	loggedMeta, ok := logged.(Metadata)
+	if !ok {
+		t.Fatalf("MarshalLog returned %T, want Metadata", logged)
+	}
+	if loggedMeta.VolumeContext["csi.storage.k8s.io/pod.name"] != "other-pod" {
+		t.Error("keys dropped from Metadata that has no SA token")
+	}
+}
+
+// TestMetadata_MarshalLog_tokenNeverInFormattedOutput verifies the
+// security property directly: when a logr backend formats the MarshalLog
+// return value with %v (the standard fallback for struct types), the raw
+// token must not appear in the output string.
+func TestMetadata_MarshalLog_tokenNeverInFormattedOutput(t *testing.T) {
+	m := Metadata{
+		VolumeID: "vol-123",
+		VolumeContext: map[string]string{
+			SATokenVolumeContextKey: testToken,
+		},
+	}
+
+	formatted := fmt.Sprintf("%v", m.MarshalLog())
+
+	for _, needle := range []string{"secret", "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9"} {
+		if strings.Contains(formatted, needle) {
+			t.Errorf("MarshalLog output contains token (found %q):\n%s", needle, formatted)
+		}
+	}
+	if !strings.Contains(formatted, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] marker in output:\n%s", formatted)
+	}
+}


### PR DESCRIPTION
# Description:

protosanitizer.StripSecrets only redacts protobuf fields annotated csi_secret. The volume_context field — where kubelet injects the mounting pod's ServiceAccount bearer token when spec.tokenRequests is set — carries no such annotation and passed through untouched. This caused live SA tokens to appear in logs at default verbosity on any NodePublishVolume handler error (readOnly unset, issuer timeout, etc.), and at -v=2/-v=3 on every issuance and renewal.

Changes:
  - driver/server.go — redactSATokens() proto-clones the request and replaces the token value with [REDACTED] before passing to protosanitizer.StripSecrets. The handler receives the original unmodified request.
  - metadata/metadata.go — implements logr.Marshaler on Metadata so any logr backend automatically redacts the token when logging the struct (fixes the manager.go:398 sink). Exports SATokenVolumeContextKey as the canonical constant.
  - manager/util/tokenrequest.go — uses the new constant instead of the duplicated string literal.
  - driver/server_test.go & metadata/metadata_test.go — Automated testing added.

  Manual test output using klog (the production logging backend) against all three sinks:

  # Sink #3 — error level, default verbosity (fires in production on any handler failure)
  E server.go:113] "failed processing request" err="pod.spec.volumes[].csi.readOnly must be set to 'true'"
    rpc_method="/csi.v1.Node/NodePublishVolume"
    request={"volume_context":{"csi.storage.k8s.io/serviceAccount.tokens":"[REDACTED]",...},...}

  # Sink #1 — V(3) entry log
  I server.go:110] "handling request"
    request={"volume_context":{"csi.storage.k8s.io/serviceAccount.tokens":"[REDACTED]",...},...}

  # Sink #2 — V(2) Read metadata (manager.go:398)
  I] "Read metadata"
    metadata={"volumeContext":{"csi.storage.k8s.io/serviceAccount.tokens":"[REDACTED]",...}}

  Tests also confirm the handler receives the original unredacted token so ClientForMetadataTokenRequestEmptyAud continues to work.