### PR TITLE
fix: use cmmeta.IssuerReference instead of deprecated cmmeta.ObjectReference

### DIFF
--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -226,7 +226,7 @@ func generateRequest(meta metadata.Metadata) (*manager.CertificateRequestBundle,
 		Namespace: namespace,
 		Duration:  duration,
 		Usages:    keyUsagesFromAttributes(meta.VolumeContext[KeyUsagesKey]),
-		IssuerRef: cmmeta.ObjectReference{
+		IssuerRef: cmmeta.IssuerReference{
 			Name:  meta.VolumeContext[IssuerNameKey],
 			Kind:  meta.VolumeContext[IssuerKindKey],
 			Group: meta.VolumeContext[IssuerGroupKey],

--- a/manager/interfaces.go
+++ b/manager/interfaces.go
@@ -71,7 +71,7 @@ type CertificateRequestBundle struct {
 	Namespace string
 
 	// The IssuerRef to be added to the CertificateRequest.
-	IssuerRef cmmeta.ObjectReference
+	IssuerRef cmmeta.IssuerReference
 
 	// Request duration/validity period of the certificate
 	Duration time.Duration

--- a/metrics/certificaterequest_test.go
+++ b/metrics/certificaterequest_test.go
@@ -80,7 +80,7 @@ func TestCertificateRequestMetrics(t *testing.T) {
 		"certificate with expiry and ready status": {
 			cr: gen.CertificateRequest("test-certificate-request",
 				gen.SetCertificateRequestNamespace("test-ns"),
-				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
+				gen.SetCertificateRequestIssuer(cmmeta.IssuerReference{
 					Name:  "test-issuer",
 					Kind:  "test-issuer-kind",
 					Group: "test-issuer-group",
@@ -107,7 +107,7 @@ func TestCertificateRequestMetrics(t *testing.T) {
 		"certificate with no expiry and no status should give an expiry of 0 and Unknown status": {
 			cr: gen.CertificateRequest("test-certificate-request",
 				gen.SetCertificateRequestNamespace("test-ns"),
-				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
+				gen.SetCertificateRequestIssuer(cmmeta.IssuerReference{
 					Name:  "test-issuer",
 					Kind:  "test-issuer-kind",
 					Group: "test-issuer-group",
@@ -129,7 +129,7 @@ func TestCertificateRequestMetrics(t *testing.T) {
 		"certificate with expiry and status False should give an expiry and False status": {
 			cr: gen.CertificateRequest("test-certificate-request",
 				gen.SetCertificateRequestNamespace("test-ns"),
-				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
+				gen.SetCertificateRequestIssuer(cmmeta.IssuerReference{
 					Name:  "test-issuer",
 					Kind:  "test-issuer-kind",
 					Group: "test-issuer-group",
@@ -156,7 +156,7 @@ func TestCertificateRequestMetrics(t *testing.T) {
 		"certificate with expiry and status Unknown should give an expiry and Unknown status": {
 			cr: gen.CertificateRequest("test-certificate-request",
 				gen.SetCertificateRequestNamespace("test-ns"),
-				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
+				gen.SetCertificateRequestIssuer(cmmeta.IssuerReference{
 					Name:  "test-issuer",
 					Kind:  "test-issuer-kind",
 					Group: "test-issuer-group",
@@ -183,7 +183,7 @@ func TestCertificateRequestMetrics(t *testing.T) {
 		"certificate with expiry and ready status and renew before": {
 			cr: gen.CertificateRequest("test-certificate-request",
 				gen.SetCertificateRequestNamespace("test-ns"),
-				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
+				gen.SetCertificateRequestIssuer(cmmeta.IssuerReference{
 					Name:  "test-issuer",
 					Kind:  "test-issuer-kind",
 					Group: "test-issuer-group",
@@ -276,7 +276,7 @@ func TestCertificateRequestCache(t *testing.T) {
 
 	cr1 := gen.CertificateRequest("cr1",
 		gen.SetCertificateRequestNamespace("testns"),
-		gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
+		gen.SetCertificateRequestIssuer(cmmeta.IssuerReference{
 			Name:  "test-issuer",
 			Kind:  "test-issuer-kind",
 			Group: "test-issuer-group",
@@ -290,7 +290,7 @@ func TestCertificateRequestCache(t *testing.T) {
 	)
 	cr2 := gen.CertificateRequest("cr2",
 		gen.SetCertificateRequestNamespace("testns"),
-		gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
+		gen.SetCertificateRequestIssuer(cmmeta.IssuerReference{
 			Name:  "test-issuer",
 			Kind:  "test-issuer-kind",
 			Group: "test-issuer-group",
@@ -304,7 +304,7 @@ func TestCertificateRequestCache(t *testing.T) {
 	)
 	cr3 := gen.CertificateRequest("cr3",
 		gen.SetCertificateRequestNamespace("testns"),
-		gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
+		gen.SetCertificateRequestIssuer(cmmeta.IssuerReference{
 			Name:  "test-issuer",
 			Kind:  "test-issuer-kind",
 			Group: "test-issuer-group",

--- a/test/integration/metrics_test.go
+++ b/test/integration/metrics_test.go
@@ -161,7 +161,7 @@ func TestMetricsServer(t *testing.T) {
 		GenerateRequest: func(meta metadata.Metadata) (*manager.CertificateRequestBundle, error) {
 			return &manager.CertificateRequestBundle{
 				Namespace: testNamespace,
-				IssuerRef: cmmeta.ObjectReference{
+				IssuerRef: cmmeta.IssuerReference{
 					Name:  "test-issuer",
 					Kind:  "test-issuer-kind",
 					Group: "test-issuer-group",


### PR DESCRIPTION
`cmmeta.ObjectReference` is a deprecated alias of `cmmeta.IssuerReference` since cert-manager v1.20 and is removed entirely in cert-manager v1.21.

Renaming now (the alias makes this a no-op with the current cert-manager v1.20.3 dependency) unblocks #258, which bumps cert-manager to v1.21.1 and currently fails to compile because of this. Renovate keeps force-push rebasing #258, so a fix commit pushed to its branch gets clobbered — landing the rename on main instead means the next Renovate rebase of #258 will compile as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)