### PR TITLE
fix(manager): return an error instead of panicking on a non-PEM issued chain

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -981,6 +981,10 @@ func (m *Manager) Stop() {
 // NotBefore).
 func calculateNextIssuanceTime(chain []byte) (time.Time, error) {
 	block, _ := pem.Decode(chain)
+	if block == nil {
+		return time.Time{}, errors.New("parsing issued certificate: no PEM data found in the issued chain")
+	}
+
 	crt, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("parsing issued certificate: %w", err)

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -671,18 +671,40 @@ func Test_calculateNextIssuanceTime(t *testing.T) {
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 
 	tests := map[string]struct {
+		chain   []byte
 		expTime time.Time
 		expErr  bool
 	}{
 		"if no attributes given, return 2/3rd certificate lifetime": {
+			chain:   certPEM,
 			expTime: notBefore.AddDate(0, 0, 2),
 			expErr:  false,
+		},
+		"a nil chain is rejected": {
+			chain:  nil,
+			expErr: true,
+		},
+		"an empty chain is rejected": {
+			chain:  []byte{},
+			expErr: true,
+		},
+		"a chain that is not PEM is rejected": {
+			chain:  []byte("this is not a PEM encoded certificate"),
+			expErr: true,
+		},
+		"a truncated PEM block is rejected": {
+			chain:  certPEM[:len(certPEM)/2],
+			expErr: true,
+		},
+		"a PEM block that is not a certificate is rejected": {
+			chain:  pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not DER")}),
+			expErr: true,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			renewTime, err := calculateNextIssuanceTime(certPEM)
+			renewTime, err := calculateNextIssuanceTime(test.chain)
 			assert.Equal(t, test.expErr, err != nil)
 			assert.Equal(t, test.expTime, renewTime)
 		})


### PR DESCRIPTION
Picked up from the open follow-ups in cert-manager/cert-manager#9155:

> Latent nil-pointer panic in `calculateNextIssuanceTime`: the `pem.Decode` result is used without a nil check, so a corrupt stored certificate panics the driver.

## The bug

`pem.Decode` returns a **nil** block when the input contains no PEM data. `calculateNextIssuanceTime` dereferenced it immediately:

```go
block, _ := pem.Decode(chain)
crt, err := x509.ParseCertificate(block.Bytes)   // panics when block == nil
```

`chain` is `req.Status.Certificate` — written by the signer, not by the driver. Any external issuer that marks a `CertificateRequest` `Ready=True` while putting something other than PEM in `status.certificate` (a truncated write, a base64 mix-up, a header-only blob) takes the driver process down instead of failing that one volume. There is no CRD-level schema validation on that field, so nothing upstream of this line rejects it.

The caller already treats the function as fallible — it wraps the result in `calculating next issuance time` — and drivers built on this library call it *before* writing anything, precisely so a failure leaves no partial state on disk (csi-driver-spiffe says so in a comment). A panic bypasses all of that.

## The fix

Return an error when there is no PEM block, matching the wording of the `x509.ParseCertificate` failure right below it. Four lines, no behaviour change for any input that already parsed.

## Verification

- **Revert-checked**: with `manager.go` restored to `main` and the new tests kept, the run ends in `panic: runtime error: invalid memory address or nil pointer dereference`. With the fix, all six cases pass.
- New cases cover nil, empty, non-PEM, a truncated PEM block, and a PEM block whose contents are not DER. The last one is deliberate: it goes through the pre-existing `ParseCertificate` error path, so the test also shows the new branch is not swallowing errors that were already handled.
- The existing case (2/3rds of the lifetime) is unchanged; the table just gained an explicit `chain` field, since it previously ignored its own input.
- `go test ./...` failure set is **identical** to a pristine tree on this machine (`storage` ×4 and `test/integration` ×2 fail on `main` too — Windows checkout, not related to this change). `gofmt` and `go vet` clean.

The same one-line omission exists in csi-driver-spiffe's own copy of this function; filed alongside as cert-manager/csi-driver-spiffe#594.

---

*Written with assistance from Claude (Opus 5); the analysis, tests and verification above were run and checked by me.*
